### PR TITLE
Fix debian dockerfile template. Install iproute2 instead if iproute package is not available

### DIFF
--- a/contracts/sw.os+arch.sw/debian/base-dependencies.tpl
+++ b/contracts/sw.os+arch.sw/debian/base-dependencies.tpl
@@ -5,8 +5,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gnupg \
   dirmngr \
   inetutils-ping \
-  iproute \
   netbase \
   curl \
   udev \
+  $( \
+      if apt-cache show 'iproute' 2>/dev/null | grep -q '^Version:'; then \
+        echo 'iproute'; \
+      else \
+        echo 'iproute2'; \
+      fi \
+  ) \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Connects to https://github.com/resin-io-library/base-images/pull/409