### PR TITLE
base-images: Add deprecation warning when using resin base images

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,14 @@
-machine:
-  node:
-    version: 8.11.2
+version: 2
+jobs:
+  build:
+    working_directory: /tmp/build
+    docker:
+      - image: circleci/node:8.11.2
+    steps:
+      - checkout
+      - run:
+          name: install-npm-wee
+          command: npm install
+      - run:
+          name: test
+          command: npm run test

--- a/contracts/sw.os+arch.sw/tini.tpl
+++ b/contracts/sw.os+arch.sw/tini.tpl
@@ -5,3 +5,17 @@ RUN curl -SLO "{{sw.blob.tini.assets.bin.url}}" \
   && rm "{{sw.blob.tini.assets.bin.name}}" \
   && chmod +x {{sw.blob.tini.assets.bin.main}} \
   && mv {{sw.blob.tini.assets.bin.main}} /sbin/{{sw.blob.tini.assets.bin.main}}
+
+RUN mkdir -p /.resin && echo $'\n\
+ __      ___   ___ _  _ ___ _  _  ___ \n\
+ \ \    / /_\ | _ \ \| |_ _| \| |/ __|\n\
+  \ \/\/ / _ \|   / .` || || .` | (_ |\n\
+   \_/\_/_/ \_\_|_\_|\_|___|_|\_|\___|\n\
+======================================\n\
+resin base images have been deprecated\n\
+in favour of the new balenalib images,\n\
+read more about it in our docs:\n\
+https://www.balena.io/docs/reference/base-images/base-images/\n\
+======================================' > /.resin/deprecation-warning
+
+ONBUILD RUN cat /.resin/deprecation-warning


### PR DESCRIPTION
Balenalib base images are released, we can deprecate the resin base images now

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>