### PR TITLE
imx8m-var-dart: Add identification led support

### DIFF
--- a/contracts/hw.device-type/imx8m-var-dart/contract.json
+++ b/contracts/hw.device-type/imx8m-var-dart/contract.json
@@ -6,7 +6,7 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
-    "led": false,
+    "led": true,
     "connectivity": {
       "bluetooth": true,
       "wifi": true


### PR DESCRIPTION
Led support added by https://github.com/balena-os/balena-variscite/pull/86