### PR TITLE
node: Add glibc i386 binary for v10.15.3

### DIFF
--- a/contracts/sw.stack/node/contract.json
+++ b/contracts/sw.stack/node/contract.json
@@ -425,6 +425,18 @@
               "requires": [
                 { "type": "arch.sw", "slug": "aarch64" }
               ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "44ce9c952b00004c44b853914b9ccba9a981b8248bc1d4a2eb02a8a47d950ceb",
+                  "name": "node-v$NODE_VERSION-linux-i386.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "i386" }
+              ]
             }
           ]
         }


### PR DESCRIPTION
There are unofficial builds for i386 v10.x so we can add it back to balenalib base images.

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>