### PR TITLE
install_packages: Fix cleanup command

### DIFF
--- a/contracts/sw.os+arch.sw/debian+i386-nlp/base-dependencies.tpl
+++ b/contracts/sw.os+arch.sw/debian+i386-nlp/base-dependencies.tpl
@@ -39,7 +39,7 @@ until [ $n -gt $max ]; do\n\
   echo "apt failed, retrying"\n\
   n=$(($n + 1))\n\
 done\n\
-rm -r /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
+rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
   && chmod 0755 "/usr/sbin/install_packages"
 
 RUN set -x \

--- a/contracts/sw.os+arch.sw/debian/base-dependencies.tpl
+++ b/contracts/sw.os+arch.sw/debian/base-dependencies.tpl
@@ -40,7 +40,7 @@ until [ $n -gt $max ]; do\n\
   echo "apt failed, retrying"\n\
   n=$(($n + 1))\n\
 done\n\
-rm -r /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
+rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
   && chmod 0755 "/usr/sbin/install_packages"
 
 {{import partial=sw.stack-variant.slug combination="sw.os+arch.sw"}}

--- a/contracts/sw.os+arch.sw/debian@buster/base-dependencies.tpl
+++ b/contracts/sw.os+arch.sw/debian@buster/base-dependencies.tpl
@@ -41,7 +41,7 @@ until [ $n -gt $max ]; do\n\
   echo "apt failed, retrying"\n\
   n=$(($n + 1))\n\
 done\n\
-rm -r /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
+rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
   && chmod 0755 "/usr/sbin/install_packages"
 
 {{import partial=sw.stack-variant.slug combination="sw.os+arch.sw"}}

--- a/contracts/sw.os+arch.sw/debian@jessie+aarch64/base-dependencies.tpl
+++ b/contracts/sw.os+arch.sw/debian@jessie+aarch64/base-dependencies.tpl
@@ -40,7 +40,7 @@ until [ $n -gt $max ]; do\n\
   echo "apt failed, retrying"\n\
   n=$(($n + 1))\n\
 done\n\
-rm -r /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
+rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
   && chmod 0755 "/usr/sbin/install_packages"
 
 {{import partial=sw.stack-variant.slug combination="sw.os+arch.sw"}}

--- a/contracts/sw.os+arch.sw/debian@jessie/base-dependencies.tpl
+++ b/contracts/sw.os+arch.sw/debian@jessie/base-dependencies.tpl
@@ -41,7 +41,7 @@ until [ $n -gt $max ]; do\n\
   echo "apt failed, retrying"\n\
   n=$(($n + 1))\n\
 done\n\
-rm -r /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
+rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
   && chmod 0755 "/usr/sbin/install_packages"
 
 {{import partial=sw.stack-variant.slug combination="sw.os+arch.sw"}}

--- a/contracts/sw.os+arch.sw/ubuntu+i386-nlp/base-dependencies.tpl
+++ b/contracts/sw.os+arch.sw/ubuntu+i386-nlp/base-dependencies.tpl
@@ -39,7 +39,7 @@ until [ $n -gt $max ]; do\n\
   echo "apt failed, retrying"\n\
   n=$(($n + 1))\n\
 done\n\
-rm -r /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
+rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
   && chmod 0755 "/usr/sbin/install_packages"
 
 RUN set -x \

--- a/contracts/sw.os+arch.sw/ubuntu/base-dependencies.tpl
+++ b/contracts/sw.os+arch.sw/ubuntu/base-dependencies.tpl
@@ -39,7 +39,7 @@ until [ $n -gt $max ]; do\n\
   echo "apt failed, retrying"\n\
   n=$(($n + 1))\n\
 done\n\
-rm -r /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
+rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
   && chmod 0755 "/usr/sbin/install_packages"
 
 {{import partial=sw.stack-variant.slug combination="sw.os+arch.sw"}}


### PR DESCRIPTION
Make sure the cleanup command will not fail when removing non-existent directories

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>