### PR TITLE
Few base image updates

### DIFF
--- a/contracts/sw.os+arch.sw/ubuntu@disco/base-dependencies.tpl
+++ b/contracts/sw.os+arch.sw/ubuntu@disco/base-dependencies.tpl
@@ -1,0 +1,46 @@
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  sudo \
+  ca-certificates \
+  findutils \
+  gnupg \
+  dirmngr \
+  inetutils-ping \
+  netbase \
+  curl \
+  udev \
+  $( \
+      if apt-cache show 'iproute' 2>/dev/null | grep -q '^Version:'; then \
+        echo 'iproute'; \
+      else \
+        echo 'iproute2'; \
+      fi \
+  ) \
+  && rm -rf /var/lib/apt/lists/* \
+  && c_rehash \
+  && echo '#!/bin/sh\n\
+set -e\n\
+set -u\n\
+export DEBIAN_FRONTEND=noninteractive\n\
+n=0\n\
+max=2\n\
+until [ $n -gt $max ]; do\n\
+  set +e\n\
+  (\n\
+    apt-get update -qq &&\n\
+    apt-get install -y --no-install-recommends "$@"\n\
+  )\n\
+  CODE=$?\n\
+  set -e\n\
+  if [ $CODE -eq 0 ]; then\n\
+    break\n\
+  fi\n\
+  if [ $n -eq $max ]; then\n\
+    exit $CODE\n\
+  fi\n\
+  echo "apt failed, retrying"\n\
+  n=$(($n + 1))\n\
+done\n\
+rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
+  && chmod 0755 "/usr/sbin/install_packages"
+
+{{import partial=sw.stack-variant.slug combination="sw.os+arch.sw"}}

--- a/contracts/sw.os+arch.sw/ubuntu@eoan/base-dependencies.tpl
+++ b/contracts/sw.os+arch.sw/ubuntu@eoan/base-dependencies.tpl
@@ -1,0 +1,46 @@
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  sudo \
+  ca-certificates \
+  findutils \
+  gnupg \
+  dirmngr \
+  inetutils-ping \
+  netbase \
+  curl \
+  udev \
+  $( \
+      if apt-cache show 'iproute' 2>/dev/null | grep -q '^Version:'; then \
+        echo 'iproute'; \
+      else \
+        echo 'iproute2'; \
+      fi \
+  ) \
+  && rm -rf /var/lib/apt/lists/* \
+  && c_rehash \
+  && echo '#!/bin/sh\n\
+set -e\n\
+set -u\n\
+export DEBIAN_FRONTEND=noninteractive\n\
+n=0\n\
+max=2\n\
+until [ $n -gt $max ]; do\n\
+  set +e\n\
+  (\n\
+    apt-get update -qq &&\n\
+    apt-get install -y --no-install-recommends "$@"\n\
+  )\n\
+  CODE=$?\n\
+  set -e\n\
+  if [ $CODE -eq 0 ]; then\n\
+    break\n\
+  fi\n\
+  if [ $n -eq $max ]; then\n\
+    exit $CODE\n\
+  fi\n\
+  echo "apt failed, retrying"\n\
+  n=$(($n + 1))\n\
+done\n\
+rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*' > /usr/sbin/install_packages \
+  && chmod 0755 "/usr/sbin/install_packages"
+
+{{import partial=sw.stack-variant.slug combination="sw.os+arch.sw"}}

--- a/contracts/sw.stack/node/contract.json
+++ b/contracts/sw.stack/node/contract.json
@@ -4,14 +4,14 @@
   "name": "Node.js $NODE_VERSION",
   "version": "1",
   "data": {
-    "latest": "12.11.0",
-    "versionList": "`12.11.0 (latest)`, `11.15.0`, `10.16.3`, `9.11.2`, `8.16.1`, `6.17.1`",
+    "latest": "13.0.1",
+    "versionList": "`13.0.1 (latest)`, `12.13.0`, `11.15.0`, `10.17.0`, `9.11.2`, `8.16.1`, `6.17.1`",
     "introduction": "Node.js is a software platform for scalable server-side and networking applications. Node.js applications are written in JavaScript and can be run within the Node.js runtime on Mac OS X, Windows, and Linux without changes.\n\nNode.js applications are designed to maximize throughput and efficiency, using non-blocking I/O and asynchronous events. Node.js applications run single-threaded, although Node.js uses multiple threads for file and network events. Node.js is commonly used for real-time applications due to its asynchronous nature.\n\nNode.js internally uses the Google V8 JavaScript engine to execute code; a large percentage of the basic modules are written in JavaScript. Node.js contains a built-in, asynchronous I/O library for file, socket, and HTTP communication. The HTTP and socket support allows Node.js to act as a web server without additional software such as Apache.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/node/logo.png"
   },
   "assets": {
     "yarn": {
-      "version": "1.17.3"
+      "version": "1.19.1"
     },
     "test": {
       "main": "test-stack@node",
@@ -30,7 +30,7 @@
   ],
   "variants": [
     {
-      "version": "12.11.0",
+      "version": "13.0.1",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -41,7 +41,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "15f4c55303728826382474e509ab1862b693d1058ac950de45d7a570d0e4d3d8",
+                  "checksum": "294e9cfe225fc0891d332daf12612a88c38deef8633dd6b0eaac33193dee1fc7",
                   "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -53,7 +53,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a7deca2dcd71012bceeee285c7f1c3820efbf2c013dd0756af569de9cc1a6bc0",
+                  "checksum": "95bdf07645e955c66f54ce89882fae2e7da20656744e66e6547d1c701f384af8",
                   "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -65,7 +65,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "d93351af20a61ec41f380db712fb238552fe3f5f16d027c104edee7d0c182cac",
+                  "checksum": "e0f98095bd2dbe71fa3dae91b18d5a9a438a94435d81c48939c5c8b2dfba6e10",
                   "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -77,7 +77,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "420fa3df2e3cdd680f6b2bf6d84c08c2da53b4dc4819e7b6e83521a1d6f60756",
+                  "checksum": "2b0cd5e178bd341d4d650cddb36df45b61f9c68486df31b8e5db5c0a8b933587",
                   "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -89,7 +89,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "e022341ea7b37677994ba9ce29f56f5a1ddaa7487da9eb8d1cd73902c5532079",
+                  "checksum": "5db9306aec170c5ad198c71ba8eb884ba26d665539af6a965f58cef547aa1d41",
                   "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -115,7 +115,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "e4ed3a848474bf7affaa32d36977c9607a719984de71ef0ee0882040f406b3e6",
+                  "checksum": "99d98d2621909ac0f52473e0e9c6159cd7c17e21ea993740f6dbeddbf2af2f08",
                   "name": "node-v$NODE_VERSION-linux-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -127,7 +127,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f20cdbbe0a6129d25cd64e03610a0e036864dec5ee0973e1b9db61bd84a11e51",
+                  "checksum": "1ac9b16adf01069170bf685dc0497d83d7f690492f83cc29a1c6a5950b914661",
                   "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -139,7 +139,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "66f99ceb83128fae568659caaa8f2202680c2e89296513605883f81e88d75dc3",
+                  "checksum": "7476f43e45a896c95c5995c6f904aa5fb5d7347a25eaa95ce80043892b3926a4",
                   "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -151,7 +151,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "8988bf487317766b3d84f9b9075c302eaa2a35c768640c99d1f7b0c4ba10bbda",
+                  "checksum": "437dc656d94e295d9200425b0d0dd000eed67fbc090334a5da51c77a8895b136",
                   "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -163,7 +163,154 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "ac556d52f37050111a88d2dd8c2ef5c5d5fc2f809eb1b1a9e4cda02433a10569",
+                  "checksum": "90b0d4f75322dfe1119c43fc6f958400c8e9664b8ff014eb1d3bf6af27b85a78",
+                  "name": "node-v$NODE_VERSION-linux-i386.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "i386" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "12.13.0",
+      "variants": [
+        {
+          "data": { "libc": "musl-libc" },
+          "requires": [
+            { "type": "sw.os", "slug": "alpine" }
+          ],
+          "variants": [
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "045a420ec2004fa10a2bcbc65d99cd9bcf63afd8e6b877be32368dcc783acf81",
+                  "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "rpi" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "03ea000991375dae2c354c55b8d42fc690b8b94032b13226080729642f85434d",
+                  "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "amd64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "d0ca6d4aab93ffe403b3dfa055c94868c571745b9dda598a58b6047257e18f12",
+                  "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "i386" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "e05024cf3755374294e4d3a948a9fc273d37c4c037338c644069a73a0022b8f9",
+                  "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "aarch64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "4c01142826ebd38044a6d3a4d92e15cc0a645195185f9052d68f4b8c094f709b",
+                  "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "armv7hf" }
+              ]
+            }
+          ]
+        },
+        {
+          "data": { "libc": "glibc" },
+          "requires": [
+            {
+              "or": [
+                { "type": "sw.os", "slug": "debian" },
+                { "type": "sw.os", "slug": "ubuntu" },
+                { "type": "sw.os", "slug": "fedora" }
+              ]
+            }
+          ],
+          "variants": [
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "dfcf79cf537a14583a414014bd7b3264f54535cc19fcaac7ba30b940218316d3",
+                  "name": "node-v$NODE_VERSION-linux-armv6hf.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "rpi" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "c8bb1fca0712f360eaeeeab064426f8fb6f9af50144658aa1b50c9703fc7f680",
+                  "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
+                  "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "armv7hf" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "c69671c89d0faa47b64bd5f37079e4480852857a9a9366ee86cdd8bc9670074a",
+                  "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
+                  "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "amd64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "92371c7f1edd384a8acb0d2b9f2deac76e911588669b71de9f6453012196c970",
+                  "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
+                  "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "aarch64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "04c17252fd50f938acf1af8ae36fff88371913d0832bcbafab790dfea453ace4",
                   "name": "node-v$NODE_VERSION-linux-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -313,7 +460,7 @@
       ]
     },
     {
-      "version": "10.16.3",
+      "version": "10.17.0",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -324,7 +471,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c7f0da3a32d6b3faab2c2b6bb569ebe2e62cdea425d99e4b3e74549e18100735",
+                  "checksum": "f6ccb475cd8096bb4fe2709c6e0db8fc671ded7e4b667aca6949f379cc515d2d",
                   "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -336,7 +483,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "42b4b5f7b7c1b68190722f2fd0bf63a4ec5725554746217a5fcaafe468a684f0",
+                  "checksum": "0abcd554c19eb0a8193e2efe219ee7e440bfc9312c9d035f905066c67d5edcba",
                   "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -348,7 +495,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "9624c33b46d5842a94cc3a01ce35737ff58edbb62065f82af9e6499a03363e0f",
+                  "checksum": "f666926e831ce43e8a5537a597f4daadc4064fdeb74450f7991f1b15a00a127a",
                   "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -360,7 +507,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "31b978ea84897d982ec0000539c6810f57aba1d68fcf6390fa7673c169ffed44",
+                  "checksum": "ae5a5c818c9cb7ce8928310f6f9beba994a941eea08971e6fc0d960dcb99187d",
                   "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -372,7 +519,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "581d9c264e84a92c79fc804302ce792e6f58e82534c36f4c83f2d4ae3ab708ee",
+                  "checksum": "31b3901e16f0608f965986ee4598f3d851957cb7524d6c63e88015a9e28fa748",
                   "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -398,7 +545,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c4ce8f8627c4d0d71647987924e5369cd1adeef2865bf1bdbb4387b75fba804b",
+                  "checksum": "bc47d0ec1b70525558508962453456fda2b0c21013e2a6996479efbb8b96c518",
                   "name": "node-v$NODE_VERSION-linux-armv6l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -410,7 +557,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f267710728ca56ca3b522076fff808540ea27d6aa5fd586bc0ad39c389530c3b",
+                  "checksum": "6e7316b9a3e48c9cadfaa09adb89ee31ca00d803cdf7dd63687f4a6bf87070d4",
                   "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -422,7 +569,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "2f0397bb81c1d0c9901b9aff82a933257bf60f3992227b86107111a75b9030d9",
+                  "checksum": "417bdc5402f6510fe1a5a898a9cdf1d67bd0202b5f014051c382f05358999534",
                   "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -434,7 +581,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3bab16e7107092e43426e082ee9fd88ef0a43a35816f662f14563bcc5152600d",
+                  "checksum": "fca7862a435c48d634fd74464057edef0e6ed854678c4b1fee3f21f126f2d7c7",
                   "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -446,7 +593,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "485bf0d79ceea814b484e768365ccfed545ae54c0d00b4c678471e34c74e32bf",
+                  "checksum": "6ad4b2d62fab43ae73be0239156e9c40e5e5e61faad89b3bbb4e4357622a3e34",
                   "name": "node-v$NODE_VERSION-linux-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }

--- a/contracts/sw.stack/python/contract.json
+++ b/contracts/sw.stack/python/contract.json
@@ -4,18 +4,18 @@
   "name": "Python $PYTHON_VERSION",
   "version": "1",
   "data": {
-    "latest": "2.7.16",
-    "versionList": "`2.7.16 (latest)`, `3.7.4`, `3.6.9`, `3.5.7`, `3.4.10`",
+    "latest": "2.7.17",
+    "versionList": "`2.7.17 (latest)`, `3.8.0`, `3.7.5`, `3.6.9`, `3.5.7`, `3.4.10`",
     "introduction": "Python is an interpreted, interactive, object-oriented, open-source programming language. It incorporates modules, exceptions, dynamic typing, very high level dynamic data types, and classes. Python combines remarkable power with very clear syntax. It has interfaces to many system calls and libraries, as well as to various window systems, and is extensible in C or C++. It is also usable as an extension language for applications that need a programmable interface. Finally, Python is portable: it runs on many Unix variants, on the Mac, and on Windows 2000 and later.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/python/logo.png"
 
   },
   "assets": {
     "pip": {
-      "version": "19.2.1"
+      "version": "19.3.1"
     },
     "setuptools": {
-      "version": "41.0.1"
+      "version": "41.6.0"
     },
     "dbus": {
       "version": "1.2.8"
@@ -37,7 +37,7 @@
   ],
   "variants": [
     {
-      "version": "3.7.4",
+      "version": "3.8.0",
       "assets" : {
         "pip": {
           "command": "pip3"
@@ -60,6 +60,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -67,7 +68,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "9a519775f13403bf30b026fb1c0d1356c1f86cdd4773b9f40cd23a3e2c785d4a",
+                      "checksum": "5a2e1959e9df5056833b167425fbea06f409246b676e0a510382bdfd11bb1c99",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -76,7 +77,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "0642efe7dda699a9c2a552f8ab475ee8cc2a21273848f00096f8c206d9eca00f",
+                      "checksum": "56ce308b48c95a3d306979902755ba1a6ba700df675c5e4372f17a3c2bc9d88d",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -103,6 +104,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -110,7 +112,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "5c4f8ce8933074e757db1af398ae7c511503e63531026e2d029b9b0ef4e2d0e8",
+                      "checksum": "aa1890973ca18596616cd20b14b99e0bd932b56ad95b147a89edc0af4934d876",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-amd64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -119,7 +121,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "c8b468d00377e7e8bc655285e2419aa3e05b887d739acb98fe2640807ff8fc9c",
+                      "checksum": "b61624efd50e3707b46a00cb50b0be231bfdc31d894385970f5b38b0ab9efcae",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-amd64-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -146,6 +148,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -153,7 +156,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "a11748c7a60fbf399f72cedd84f9c4316977093121f17a0bf832e362310fe1f2",
+                      "checksum": "65e0cb524a07a191801476241edeac47b3714249697d7b5094d4d446d0d49ffa",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-i386-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -162,7 +165,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "3697d7348cb240991bd12351b32f557faed069b5d860a7dc0e74e235c8c3bd6b",
+                      "checksum": "9b969d6fd3059f38b9a5132f6bcf53be8f69686812339cb49eded703f84198b4",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-i386-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -189,6 +192,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -196,7 +200,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "a0e858845ed7a6fa09606bfcc8822526da3f6c4cbadabae406376cd38b1f1032",
+                      "checksum": "101d4dae8aa7b2270a3507b8427f0d5a1822f2228782c57d1e99a784e131ce58",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-aarch64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -205,7 +209,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "34778ca8325ae98d9267427f4cbe385d729225a56315dc1b0ebfeebdab2b3557",
+                      "checksum": "b50aa55c0932a2e2131ffb746afdb07f14a61eabac23e3ab3efb8a89fec94194",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-aarch64-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -232,6 +236,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -239,7 +244,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "ff89253c22d83e4ebe09837c841536a46c983c0f937c39ba8b6bcbba9b369033",
+                      "checksum": "210c0b225e5c857cfc36e88eeded01358befd409ccc1e482b46a71da7f990816",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv7hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -248,7 +253,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "0642efe7dda699a9c2a552f8ab475ee8cc2a21273848f00096f8c206d9eca00f",
+                      "checksum": "56ce308b48c95a3d306979902755ba1a6ba700df675c5e4372f17a3c2bc9d88d",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -278,6 +283,8 @@
                 { "type": "sw.os", "slug": "debian" , "version": "buster" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                 { "type": "sw.os", "slug": "fedora" }
               ]
             }
@@ -286,7 +293,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "2fd60cd7bcde77060d26d8fdeb2be82eb00c498c185febd8862a6c35e35b0350",
+                  "checksum": "b59b5c80be1af2aa646b470ec07e104001b71f1a347ea9ce10081b24e049fdee",
                   "name": "Python-$PYTHON_VERSION.linux-armv6hf-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -298,7 +305,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "aa2dd3b5e2ac891e4f4905244b17a6575971d4121a9d6d302c574baf6850e63d",
+                  "checksum": "a32472138fae55bbdcaadecb6dc1a299ff8c84da562252a0bf8e01af3cb04893",
                   "name": "Python-$PYTHON_VERSION.linux-armv7hf-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -310,7 +317,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "33c345d0c21d08f85282ee1427de51cd1a996b6e05812dfe014c998b05cca6bb",
+                  "checksum": "93d967927a09acb58390b57a8c6ec370c37ab207fdfb133681a33b06ec28d042",
                   "name": "Python-$PYTHON_VERSION.linux-amd64-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -322,7 +329,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "35a25ff8803eb2221bfc7261bef4f6623ce10d3ab4c089ea30b85a1e6c47b5ca",
+                  "checksum": "2aa1090095cfb9e91a3bc568063fa617fd776e080f107988b90e1e57a9e6f76e",
                   "name": "Python-$PYTHON_VERSION.linux-aarch64-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -334,7 +341,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "7259ee9bce64d1ab714d93cc183fa89283c894036cfc7c76d21f23727e3f8f26",
+                  "checksum": "e2c996e333d175baecee53f4057131c4e4a16f9bd167afd6cb15291ed3d7bbb0",
                   "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -346,7 +353,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "7259ee9bce64d1ab714d93cc183fa89283c894036cfc7c76d21f23727e3f8f26",
+                  "checksum": "e2c996e333d175baecee53f4057131c4e4a16f9bd167afd6cb15291ed3d7bbb0",
                   "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -358,7 +365,349 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f64d62e89e62afad5239e723a19598ca8c6f34c6396266c59cf06ac2a9953b48",
+                  "checksum": "45c6d378d137a409984dfb1f2c10dce69111c517db015539fb57dcfa6ea3dc7b",
+                  "name": "Python-$PYTHON_VERSION.linux-armel-openssl1.1.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "armv5e" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "3.7.5",
+      "assets" : {
+        "pip": {
+          "command": "pip3"
+        },
+        "command": "python3"
+      },
+      "variants": [
+        {
+          "data": { "libc": "musl-libc" },
+          "requires": [
+            { "type": "sw.os", "slug": "alpine" }
+          ],
+          "variants": [
+            {
+              "requires": [
+                { "type": "arch.sw", "slug": "rpi" }
+              ],
+              "variants": [
+                {
+                  "requires": [
+                    {
+                      "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "edge" }
+                      ]
+                    }
+                  ],
+                  "assets": {
+                    "bin": {
+                      "checksum": "8d786a0ff1d66552a9f39ab106a20a3dd262bb836d3cb41c3b7f3179388a4808",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.1.tar.gz",
+                      "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                    }
+                  }
+                },
+                {
+                  "assets": {
+                    "bin": {
+                      "checksum": "5ef481e9bde9ad2a37d5dc45fe65fe647e91770936e32485903f70e9800582c9",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.0.tar.gz",
+                      "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                    }
+                  },
+                  "requires": [
+                    {
+                      "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.8" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.7" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.6" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.5" }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "requires": [
+                { "type": "arch.sw", "slug": "amd64" }
+              ],
+              "variants": [
+                {
+                  "requires": [
+                    {
+                      "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "edge" }
+                      ]
+                    }
+                  ],
+                  "assets": {
+                    "bin": {
+                      "checksum": "351bcc729095642fa89e4f6fad65f8a772c2a39259d9cbc866d8e715c25df1bb",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-amd64-openssl1.1.tar.gz",
+                      "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                    }
+                  }
+                },
+                {
+                  "assets": {
+                    "bin": {
+                      "checksum": "3c5e82b060aff1843edd18da3769f0662298c06d96259c1d3425be840b9eeb8d",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-amd64-openssl1.0.tar.gz",
+                      "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                    }
+                  },
+                  "requires": [
+                    {
+                      "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.8" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.7" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.6" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.5" }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "requires": [
+                { "type": "arch.sw", "slug": "i386" }
+              ],
+              "variants": [
+                {
+                  "requires": [
+                    {
+                      "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "edge" }
+                      ]
+                    }
+                  ],
+                  "assets": {
+                    "bin": {
+                      "checksum": "b63d0237b88dad711fdd7b5cea20e551e5d65552fc8b61abae61da9ac8774d8d",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-i386-openssl1.1.tar.gz",
+                      "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                    }
+                  }
+                },
+                {
+                  "assets": {
+                    "bin": {
+                      "checksum": "ab34f50de1a2f39587a5817f507db5f6fbc5d3c0dad4a4413c93bab83d9a235f",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-i386-openssl1.0.tar.gz",
+                      "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                    }
+                  },
+                  "requires": [
+                    {
+                      "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.8" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.7" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.6" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.5" }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "requires": [
+                { "type": "arch.sw", "slug": "aarch64" }
+              ],
+              "variants": [
+                {
+                  "requires": [
+                    {
+                      "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "edge" }
+                      ]
+                    }
+                  ],
+                  "assets": {
+                    "bin": {
+                      "checksum": "9b7388d0f3d6becfd5117bf4efb7490090c6d42fc6e0cc86e095901399b0be80",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-aarch64-openssl1.1.tar.gz",
+                      "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                    }
+                  }
+                },
+                {
+                  "assets": {
+                    "bin": {
+                      "checksum": "7c364f11743b3d018b6378df7b8e0be62d4c1e8a10074f0ecfa98ab030f56819",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-aarch64-openssl1.0.tar.gz",
+                      "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                    }
+                  },
+                  "requires": [
+                    {
+                      "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.8" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.7" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.6" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.5" }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "requires": [
+                { "type": "arch.sw", "slug": "armv7hf" }
+              ],
+              "variants": [
+                {
+                  "requires": [
+                    {
+                      "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "edge" }
+                      ]
+                    }
+                  ],
+                  "assets": {
+                    "bin": {
+                      "checksum": "816caf658c5a7287592d73ab9b8aa5ffc25855a3edcd5a3913922707cd1bf368",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-armv7hf-openssl1.1.tar.gz",
+                      "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                    }
+                  }
+                },
+                {
+                  "assets": {
+                    "bin": {
+                      "checksum": "f1d27cfda50fefb2e5cc7b4e6f872111f21fb424b95f72b4b1e0f1cdd137f0dd",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.0.tar.gz",
+                      "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                    }
+                  },
+                  "requires": [
+                    {
+                      "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.8" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.7" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.6" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.5" }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "data": { "libc": "glibc" },
+          "requires": [
+            {
+              "or": [
+                { "type": "sw.os", "slug": "debian" , "version": "stretch" },
+                { "type": "sw.os", "slug": "debian" , "version": "sid" },
+                { "type": "sw.os", "slug": "debian" , "version": "buster" },
+                { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
+                { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
+                { "type": "sw.os", "slug": "fedora" }
+              ]
+            }
+          ],
+          "variants": [
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "1e8a493b110a024aab889812e6fabe821cfdff77f3faf4cdb2a71c887ca5a4ab",
+                  "name": "Python-$PYTHON_VERSION.linux-armv6hf-openssl1.1.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "rpi" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "b4e107a641dd895b19d26f6ef6a2afc7fcaf82bb1b2c55cabf8a147c1c11a265",
+                  "name": "Python-$PYTHON_VERSION.linux-armv7hf-openssl1.1.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "armv7hf" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "8802713a5307ace199839996d8d3466f6daea3870afb60bd651a78543b68df15",
+                  "name": "Python-$PYTHON_VERSION.linux-amd64-openssl1.1.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "amd64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "e4f94e9b77034bf0dd3d014bf47e7c806c01f85fa9936e9cdce767102f08388f",
+                  "name": "Python-$PYTHON_VERSION.linux-aarch64-openssl1.1.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "aarch64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "205df53126fcc63a316ff259606ccb018a6e16939218dc977c696f067ada3cc4",
+                  "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "i386" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "205df53126fcc63a316ff259606ccb018a6e16939218dc977c696f067ada3cc4",
+                  "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "i386-nlp" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "0c2a25953a4442cdcba1557adaf49c37d53386def3d77a00359c5b41bf86c932",
                   "name": "Python-$PYTHON_VERSION.linux-armel-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -395,6 +744,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -438,6 +788,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -481,6 +832,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -524,6 +876,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -567,6 +920,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -653,6 +1007,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -698,6 +1054,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -743,6 +1101,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -788,6 +1148,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -833,6 +1195,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -878,6 +1242,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -923,6 +1289,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -958,6 +1326,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -1001,6 +1370,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -1044,6 +1414,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -1087,6 +1458,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -1130,6 +1502,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -1216,6 +1589,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -1261,6 +1636,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -1306,6 +1683,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -1351,6 +1730,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -1396,6 +1777,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -1441,6 +1824,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -1486,6 +1871,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -2061,7 +2448,7 @@
       ]
     },
     {
-      "version": "2.7.16",
+      "version": "2.7.17",
       "assets" : {
         "pip": {
           "command": "pip"
@@ -2084,6 +2471,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -2091,7 +2479,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "22152851b46a132b9f64465cf7e4cb320c3b7d035de38e8c4f12f8240b92ff70",
+                      "checksum": "f2382876294b51960467fa8bac6648eb1b3087006ac3d4575f7fee76fc0daca8",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2100,8 +2488,8 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "bb9ca81fec3a46aef61d0232e0fdbc7cc845da8be8bcd666326f94914c594dc1",
-                      "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf.tar.gz",
+                      "checksum": "d61ab378b1660eebc41694f2333a678a09126f5f7f306876a0d6dca0ecba82bc",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
                   },
@@ -2127,6 +2515,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -2134,8 +2523,8 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "ea9bba2df2fc644c4327039a4d68cca148004bcea362cd7d79b7bc9ff7097d4f",
-                      "name": "Python-$PYTHON_VERSION.linux-alpine-amd64.tar.gz",
+                      "checksum": "fa74fb159864fe3e3dd8af93100b634572ce5faf7577adb9e712962538648c8d",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-amd64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
                   }
@@ -2143,7 +2532,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "eb8ab4d21b7d71bf80301ac649547bbcce16538958de4c8b0598d6fdae8dcbb8",
+                      "checksum": "3bd5c28b43fe75ae39ae25068035c8ff7e949ca220e2f45184d2af9c2c69ce51",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-amd64-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2170,6 +2559,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -2177,8 +2567,8 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "03f122f705c656bfc77da5bead764e51504f3dabddb12f15a0514954a61a1480",
-                      "name": "Python-$PYTHON_VERSION.linux-alpine-i386.tar.gz",
+                      "checksum": "d3d51677207d342c21ad12f9d7368e3076efefb38c139ad1d9b938c326efca53",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-i386-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
                   }
@@ -2186,7 +2576,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "068754896bb4c5894042bc9091bd7ba0e4f41c71795b1751e88d040444a19df5",
+                      "checksum": "2d4fd7a75f05df8b29b64b75cefa6020b0da976fb95e9a1d45aa215afbac3a69",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-i386-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2213,6 +2603,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -2220,7 +2611,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "cd170fc5e518ea96f02a08b9e043aa340b948a6ce5053c6ee5c3a30c1137d3b9",
+                      "checksum": "66d78cb8f7c8ef7d0062ac4e87f3a557b05bc5a4197db3cf43502b28b6bcc9d2",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-aarch64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2229,8 +2620,8 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "7e670b1c08a136b27a62fa6433c36d964e0aa21ebd6e055beaf0538b8b92b097",
-                      "name": "Python-$PYTHON_VERSION.linux-alpine-aarch64.tar.gz",
+                      "checksum": "d2fafe5fa0924a617ad743d1bbb629df088e078e862a5879c0bf26cf73d923a4",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-aarch64-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
                   },
@@ -2256,6 +2647,7 @@
                   "requires": [
                     {
                       "or": [
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.9" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
@@ -2263,7 +2655,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "a4e8d08a2c2d97eb3aa253d0dcecc36df227184cbce9596700b0b4b8acac9abb",
+                      "checksum": "63bad7e8c2677ea920748d2b77df7556dbbd342f13edca103ddf6605ab5a4670",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv7hf.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2272,8 +2664,8 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "bb9ca81fec3a46aef61d0232e0fdbc7cc845da8be8bcd666326f94914c594dc1",
-                      "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf.tar.gz",
+                      "checksum": "d61ab378b1660eebc41694f2333a678a09126f5f7f306876a0d6dca0ecba82bc",
+                      "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
                   },
@@ -2311,7 +2703,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "64023d91d0dc9d3d92ea740a3f562604a8d5ad421f02cc43e1337bd8b07c6af2",
+                      "checksum": "aa975ef83a4b1f72ab3406a19fc9a5f082f821b3ce7bdaf1cd17722c910a87d8",
                       "name": "Python-$PYTHON_VERSION.linux-armv6hf-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2320,7 +2712,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "ade61ada9d508063a46e94d53dd00af990f4b9b182e61eaa187e478f3e41b1f1",
+                      "checksum": "9d2ae157d32435c0321e8ff1f9981d1936ec4915034663dbcb8eb969fd35f888",
                       "name": "Python-$PYTHON_VERSION.linux-armv6hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2333,6 +2725,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -2356,7 +2750,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "5e6a7b6016bb50d5874d510ef6772929091eacd1dc5195783d3ed47368134640",
+                      "checksum": "9cd516c070048e30869125a9cd691ffb5e2dbc50d2b324a94d14dba7d20c1f35",
                       "name": "Python-$PYTHON_VERSION.linux-armv7hf-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2365,7 +2759,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "ac7038b91e2f60e99949373f412bdbbf2628b2bb243ba21a97b98d8f2afcde67",
+                      "checksum": "db7933cbf74cd568c9f7fc6e7ee8cf418ce36e0b1491032d997d838f2dd54b79",
                       "name": "Python-$PYTHON_VERSION.linux-armv7hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2378,6 +2772,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -2401,7 +2797,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "f6a2cfe611f750ab45421ec7079ea8ef03452e0124d25c4a02b54b5bf656564a",
+                      "checksum": "7b1fab96c61d2034a380d7a630cd2cf7c85495924dc65049ed1b0f94d41ef4a7",
                       "name": "Python-$PYTHON_VERSION.linux-amd64-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2410,7 +2806,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "1f426afe227cd3ea73cac8e8089c97e490a3ae6b7fdecd8c57dbc6e8870c5754",
+                      "checksum": "fe4f5b7a0556bb5e30a860f81ca1e74d0194f2803237a2f5c84bcf4021dc7040",
                       "name": "Python-$PYTHON_VERSION.linux-amd64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2423,6 +2819,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -2446,7 +2844,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "efca49a2458dc57e99180a1fabce378721043a9c90164a0139ccb86dfc230ac4",
+                      "checksum": "3b93148439a5f9b3b4e4adf626a022204b14fa551cb38142e3b7a757e5f921c0",
                       "name": "Python-$PYTHON_VERSION.linux-aarch64-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2455,7 +2853,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "2acd0f52dc3aa9d38344147f51ba6f18e04a463a5974bd64d3eea4f129bfdec2",
+                      "checksum": "3926fc4bb3d1ff1abaf4526bcf0a9dcf19502096254767c8387ae57b240ee247",
                       "name": "Python-$PYTHON_VERSION.linux-aarch64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2468,6 +2866,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -2491,7 +2891,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "140319a9cdc4df4f9bfa4b89d9fe5c8843ff6a8fb85e8abe57361c885e4dd7d4",
+                      "checksum": "d6f312aac240a12780d0ed6245e225d6d992ea1b54dd2b07b9a2a18526b3cca9",
                       "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2500,7 +2900,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "31402b708b83095e316286eb9aa09b115b09697185fad092d2c1c054c874356f",
+                      "checksum": "6a433ccd406450909aa600fc1a1501f9aecb963cc4737fd96c6171adcd7f8ba3",
                       "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2513,6 +2913,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }
@@ -2536,7 +2938,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "140319a9cdc4df4f9bfa4b89d9fe5c8843ff6a8fb85e8abe57361c885e4dd7d4",
+                      "checksum": "d6f312aac240a12780d0ed6245e225d6d992ea1b54dd2b07b9a2a18526b3cca9",
                       "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.0.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2545,7 +2947,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "31402b708b83095e316286eb9aa09b115b09697185fad092d2c1c054c874356f",
+                      "checksum": "6a433ccd406450909aa600fc1a1501f9aecb963cc4737fd96c6171adcd7f8ba3",
                       "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -2558,51 +2960,8 @@
                         { "type": "sw.os", "slug": "debian" , "version": "buster" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                         { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
-                        { "type": "sw.os", "slug": "fedora" }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "requires": [
-                { "type": "arch.sw", "slug": "armv5e" }
-              ],
-              "variants": [
-                {
-                  "requires": [
-                    {
-                      "or": [
-                        { "type": "sw.os", "slug": "debian" , "version": "jessie" },
-                        { "type": "sw.os", "slug": "ubuntu" , "version": "xenial" }
-                      ]
-                    }
-                  ],
-                  "assets": {
-                    "bin": {
-                      "checksum": "e01f67f27b66d73d5761e91e5097a222186c3554791bd008c7b5837e53184606",
-                      "name": "Python-$PYTHON_VERSION.linux-armel-openssl1.0.tar.gz",
-                      "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
-                    }
-                  }
-                },
-                {
-                  "assets": {
-                    "bin": {
-                      "checksum": "0e9714f6ddaac970882724352a7ad944a8b2e808dac484d11a3d8ef6315eefd1",
-                      "name": "Python-$PYTHON_VERSION.linux-armel-openssl1.1.tar.gz",
-                      "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
-                    }
-                  },
-                  "requires": [
-                    {
-                      "or": [
-                        { "type": "sw.os", "slug": "debian" , "version": "stretch" },
-                        { "type": "sw.os", "slug": "debian" , "version": "sid" },
-                        { "type": "sw.os", "slug": "debian" , "version": "buster" },
-                        { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
-                        { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
+                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
                         { "type": "sw.os", "slug": "fedora" }
                       ]
                     }


### PR DESCRIPTION
This PR has the following changes:
- node: Add v13.0.1 v12.13.0 and v10.17.0 with Yarn v1.19.1.
- python: Add v2.7.17 v3.7.5 and v3.8.0
- curl: Fix curl not working on latest Ubuntu releases