### PR TITLE
device: Add suport for Auvidea JN30B Nano

### DIFF
--- a/contracts/hw.device-type/jn30b-nano/contract.json
+++ b/contracts/hw.device-type/jn30b-nano/contract.json
@@ -1,0 +1,21 @@
+{
+  "slug": "jn30b-nano",
+  "version": "1",
+  "type": "hw.device-type",
+  "name": "Auvidea JN30B Nano",
+  "data": {
+    "arch": "aarch64",
+    "hdmi": true,
+    "led": false,
+    "connectivity": {
+      "bluetooth": false,
+      "wifi": false
+    },
+    "storage": {
+      "internal": true
+    },
+    "media": {
+      "installation": "dfu"
+    }
+  }
+}


### PR DESCRIPTION
JN30B carrier board for Jetson Nano from
Auvidea supports only the Nano production
version - with emmc.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>