### PR TITLE
device: Add Nitrogen8MM DWE board

### DIFF
--- a/contracts/hw.device-type/nitrogen8mm-dwe/contract.json
+++ b/contracts/hw.device-type/nitrogen8mm-dwe/contract.json
@@ -1,0 +1,21 @@
+{
+  "slug": "nitrogen8mm-dwe",
+  "version": "1",
+  "type": "hw.device-type",
+  "name": "Nitrogen8MM DWE",
+  "data": {
+    "arch": "aarch64",
+    "hdmi": false,
+    "led": false,
+    "connectivity": {
+      "bluetooth": true,
+      "wifi": true
+    },
+    "storage": {
+      "internal": true
+    },
+    "media": {
+      "installation": "sdcard"
+    }
+  }
+}


### PR DESCRIPTION
Add support for new device type - Nitrogen8MM DWE

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>