### PR TITLE
device: Add Nvidia Jetson TX2 with PCIe M.2 Slot Enabled

### DIFF
--- a/contracts/hw.device-type/m2pcie-tx2/contract.json
+++ b/contracts/hw.device-type/m2pcie-tx2/contract.json
@@ -1,0 +1,21 @@
+{
+  "slug": "m2pcie-tx2",
+  "version": "1",
+  "type": "hw.device-type",
+  "name": "Nvidia Jetson TX2 with PCIe M.2 Slot Enabled",
+  "data": {
+    "arch": "aarch64",
+    "hdmi": true,
+    "led": false,
+    "connectivity": {
+      "bluetooth": true
+    },
+    "storage": {
+      "internal": true,
+      "wifi": true
+    },
+    "media": {
+      "installation": "sdcard"
+    }
+  }
+}


### PR DESCRIPTION
Add support for new device type - m2pcie-tx2

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>