### PR TITLE
Add coral package sources to debian and ubuntu images

### DIFF
--- a/contracts/sw.os+hw.device-type/debian+coral-dev/dependencies.tpl
+++ b/contracts/sw.os+hw.device-type/debian+coral-dev/dependencies.tpl
@@ -1,0 +1,23 @@
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        less \
+        kmod \
+        nano \
+        net-tools \
+        ifupdown \
+        iputils-ping \
+        i2c-tools \
+        usbutils \
+        apt-transport-https \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add Google Coral sources lists
+RUN echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | tee /etc/apt/sources.list.d/coral-edgetpu.list \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+
+# Install the TPU packages
+RUN install_packages  libedgetpu1-std \
+        python3-edgetpu \
+        libedgetpu-dev
+
+RUN echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="1a6e", GROUP="plugdev"' >> /etc/udev/rules.d/99-tpu.rules \
+    && echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="18d1", GROUP="plugdev"' >> /etc/udev/rules.d/99-tpu.rules

--- a/contracts/sw.os+hw.device-type/debian@jessie+coral-dev/dependencies.tpl
+++ b/contracts/sw.os+hw.device-type/debian@jessie+coral-dev/dependencies.tpl
@@ -1,0 +1,10 @@
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        less \
+        kmod \
+        nano \
+        net-tools \
+        ifupdown \
+        iputils-ping \
+        i2c-tools \
+        usbutils \
+    && rm -rf /var/lib/apt/lists/*

--- a/contracts/sw.os+hw.device-type/ubuntu+coral-dev/dependencies.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+coral-dev/dependencies.tpl
@@ -1,0 +1,23 @@
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        less \
+        kmod \
+        nano \
+        net-tools \
+        ifupdown \
+        iputils-ping \
+        i2c-tools \
+        usbutils \
+        apt-transport-https \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add Google Coral sources lists
+RUN echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | tee /etc/apt/sources.list.d/coral-edgetpu.list \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+
+# Install the TPU packages
+RUN install_packages  libedgetpu1-std \
+        python3-edgetpu \
+        libedgetpu-dev
+
+RUN echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="1a6e", GROUP="plugdev"' >> /etc/udev/rules.d/99-tpu.rules \
+    && echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="18d1", GROUP="plugdev"' >> /etc/udev/rules.d/99-tpu.rules

--- a/contracts/sw.os+hw.device-type/ubuntu@focal+coral-dev/dependencies.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu@focal+coral-dev/dependencies.tpl
@@ -1,0 +1,10 @@
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        less \
+        kmod \
+        nano \
+        net-tools \
+        ifupdown \
+        iputils-ping \
+        i2c-tools \
+        usbutils \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Except debian jessie and ubuntu focal due to incompatible python version

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>