### PR TITLE
Add aliases field to every device type

### DIFF
--- a/contracts/hw.device-type/aio-3288c/contract.json
+++ b/contracts/hw.device-type/aio-3288c/contract.json
@@ -2,6 +2,7 @@
   "slug": "aio-3288c",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["aio-3288c"],
   "name": "AIO 3288C",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/am571x-evm/contract.json
+++ b/contracts/hw.device-type/am571x-evm/contract.json
@@ -2,6 +2,7 @@
   "slug": "am571x-evm",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "AM571X-EVM",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/apalis-imx6q/contract.json
+++ b/contracts/hw.device-type/apalis-imx6q/contract.json
@@ -2,6 +2,7 @@
   "slug": "apalis-imx6q",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["apalis-imx6"],
   "name": "Toradex Apalis",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/artik10/contract.json
+++ b/contracts/hw.device-type/artik10/contract.json
@@ -2,6 +2,7 @@
   "slug": "artik10",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Samsung Artik 10",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/artik5/contract.json
+++ b/contracts/hw.device-type/artik5/contract.json
@@ -2,6 +2,7 @@
   "slug": "artik5",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["artik520"],
   "name": "Samsung Artik 5",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/artik530/contract.json
+++ b/contracts/hw.device-type/artik530/contract.json
@@ -2,6 +2,7 @@
   "slug": "artik530",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Samsung Artik 530",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/artik533s/contract.json
+++ b/contracts/hw.device-type/artik533s/contract.json
@@ -2,6 +2,7 @@
   "slug": "artik533s",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Samsung Artik 530s 1G",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/artik710/contract.json
+++ b/contracts/hw.device-type/artik710/contract.json
@@ -2,6 +2,7 @@
   "slug": "artik710",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Samsung Artik 710",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/asus-tinker-board-s/contract.json
+++ b/contracts/hw.device-type/asus-tinker-board-s/contract.json
@@ -2,6 +2,7 @@
   "slug": "asus-tinker-board-s",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Asus Tinker Board S",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/asus-tinker-board/contract.json
+++ b/contracts/hw.device-type/asus-tinker-board/contract.json
@@ -2,6 +2,7 @@
   "slug": "asus-tinker-board",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Asus Tinker Board",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/bananapi-m1-plus/contract.json
+++ b/contracts/hw.device-type/bananapi-m1-plus/contract.json
@@ -2,6 +2,7 @@
   "slug": "bananapi-m1-plus",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "BananaPi-M1+",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/beagleboard-xm/contract.json
+++ b/contracts/hw.device-type/beagleboard-xm/contract.json
@@ -2,6 +2,7 @@
   "slug": "beagleboard-xm",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "BeagleBoard-XM",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/beaglebone-black/contract.json
+++ b/contracts/hw.device-type/beaglebone-black/contract.json
@@ -2,6 +2,7 @@
   "slug": "beaglebone-black",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["beaglebone"],
   "name": "BeagleBone Black",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/beaglebone-green-wifi/contract.json
+++ b/contracts/hw.device-type/beaglebone-green-wifi/contract.json
@@ -2,6 +2,7 @@
   "slug": "beaglebone-green-wifi",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "BeagleBone Green Wifi",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/beaglebone-green/contract.json
+++ b/contracts/hw.device-type/beaglebone-green/contract.json
@@ -2,6 +2,7 @@
   "slug": "beaglebone-green",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "BeagleBone Green",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/beaglebone-pocket/contract.json
+++ b/contracts/hw.device-type/beaglebone-pocket/contract.json
@@ -2,6 +2,7 @@
   "slug": "beaglebone-pocket",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "PocketBeagle",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/blackboard-tx2/contract.json
+++ b/contracts/hw.device-type/blackboard-tx2/contract.json
@@ -2,6 +2,7 @@
   "slug": "blackboard-tx2",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Nvidia blackboard TX2",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/cl-som-imx8/contract.json
+++ b/contracts/hw.device-type/cl-som-imx8/contract.json
@@ -2,6 +2,7 @@
   "slug": "cl-som-imx8",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Compulab iMX8",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/colibri-imx6dl/contract.json
+++ b/contracts/hw.device-type/colibri-imx6dl/contract.json
@@ -2,6 +2,7 @@
   "slug": "colibri-imx6dl",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["colibri-imx6"],
   "name": "Toradex Colibri",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/coral-dev/contract.json
+++ b/contracts/hw.device-type/coral-dev/contract.json
@@ -2,6 +2,7 @@
   "slug": "coral-dev",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Google Coral Dev Board",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/cybertan-ze250/contract.json
+++ b/contracts/hw.device-type/cybertan-ze250/contract.json
@@ -2,6 +2,7 @@
   "slug": "cybertan-ze250",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["ZE250"],
   "name": "Cybertan ze250",
   "data": {
     "arch": "i386-nlp",

--- a/contracts/hw.device-type/etcher-pro/contract.json
+++ b/contracts/hw.device-type/etcher-pro/contract.json
@@ -2,6 +2,7 @@
   "slug": "etcher-pro",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Etcher Pro",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/fincm3/contract.json
+++ b/contracts/hw.device-type/fincm3/contract.json
@@ -2,6 +2,7 @@
   "slug": "fincm3",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Balena Fin (CM3)",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/firefly-rk3288/contract.json
+++ b/contracts/hw.device-type/firefly-rk3288/contract.json
@@ -2,6 +2,7 @@
   "slug": "firefly-rk3288",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "FireFly rk3288",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/generic-aarch64/contract.json
+++ b/contracts/hw.device-type/generic-aarch64/contract.json
@@ -2,6 +2,7 @@
   "slug": "generic-aarch64",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Generic AARCH64",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/generic-armv7ahf/contract.json
+++ b/contracts/hw.device-type/generic-armv7ahf/contract.json
@@ -2,6 +2,7 @@
   "slug": "generic-armv7ahf",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Generic ARMv7-a HF",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/genericx86-64-ext/contract.json
+++ b/contracts/hw.device-type/genericx86-64-ext/contract.json
@@ -2,6 +2,7 @@
   "slug": "genericx86-64-ext",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Generic x86_64",
   "data": {
     "arch": "amd64",

--- a/contracts/hw.device-type/hummingboard/contract.json
+++ b/contracts/hw.device-type/hummingboard/contract.json
@@ -2,6 +2,7 @@
   "slug": "hummingboard",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["solidrun-imx6","cubox-i","hummingboard2"],
   "name": "Hummingboard",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/imx6ul-var-dart/contract.json
+++ b/contracts/hw.device-type/imx6ul-var-dart/contract.json
@@ -2,6 +2,7 @@
   "slug": "imx6ul-var-dart",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Dart",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/imx7-var-som/contract.json
+++ b/contracts/hw.device-type/imx7-var-som/contract.json
@@ -2,6 +2,7 @@
   "slug": "imx7-var-som",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Variscite VAR-SOM-MX7",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/imx8m-var-dart/contract.json
+++ b/contracts/hw.device-type/imx8m-var-dart/contract.json
@@ -2,6 +2,7 @@
   "slug": "imx8m-var-dart",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Variscite DART-MX8M",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/imx8mm-var-dart-nrt/contract.json
+++ b/contracts/hw.device-type/imx8mm-var-dart-nrt/contract.json
@@ -2,6 +2,7 @@
   "slug": "imx8mm-var-dart-nrt",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Variscite DART-MX8M Mini NRT",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/imx8mm-var-dart-plt/contract.json
+++ b/contracts/hw.device-type/imx8mm-var-dart-plt/contract.json
@@ -2,6 +2,7 @@
   "slug": "imx8mm-var-dart-plt",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Variscite DART-MX8M Mini PLT",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/imx8mm-var-dart/contract.json
+++ b/contracts/hw.device-type/imx8mm-var-dart/contract.json
@@ -2,6 +2,7 @@
   "slug": "imx8mm-var-dart",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Variscite DART-MX8M Mini",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/intel-edison/contract.json
+++ b/contracts/hw.device-type/intel-edison/contract.json
@@ -2,6 +2,7 @@
   "slug": "intel-edison",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["edison"],
   "name": "Intel Edison",
   "data": {
     "arch": "i386",

--- a/contracts/hw.device-type/intel-nuc/contract.json
+++ b/contracts/hw.device-type/intel-nuc/contract.json
@@ -2,6 +2,7 @@
   "slug": "intel-nuc",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["nuc"],
   "name": "Intel NUC",
   "data": {
     "arch": "amd64",

--- a/contracts/hw.device-type/iot2000/contract.json
+++ b/contracts/hw.device-type/iot2000/contract.json
@@ -2,6 +2,7 @@
   "slug": "iot2000",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Siemens IOT2000",
   "data": {
     "arch": "i386-nlp",

--- a/contracts/hw.device-type/jetson-nano/contract.json
+++ b/contracts/hw.device-type/jetson-nano/contract.json
@@ -2,6 +2,7 @@
   "slug": "jetson-nano",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Nvidia Jetson Nano",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/jetson-tx1/contract.json
+++ b/contracts/hw.device-type/jetson-tx1/contract.json
@@ -2,6 +2,7 @@
   "slug": "jetson-tx1",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Nvidia Jetson TX1",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/jetson-tx2/contract.json
+++ b/contracts/hw.device-type/jetson-tx2/contract.json
@@ -2,6 +2,7 @@
   "slug": "jetson-tx2",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Nvidia Jetson TX2",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/jetson-xavier/contract.json
+++ b/contracts/hw.device-type/jetson-xavier/contract.json
@@ -2,6 +2,7 @@
   "slug": "jetson-xavier",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Nvidia Jetson Xavier",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/jn30b-nano/contract.json
+++ b/contracts/hw.device-type/jn30b-nano/contract.json
@@ -2,6 +2,7 @@
   "slug": "jn30b-nano",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Auvidea JN30B Nano",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/kitra520/contract.json
+++ b/contracts/hw.device-type/kitra520/contract.json
@@ -2,6 +2,7 @@
   "slug": "kitra520",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "RushUp Kitra 520",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/kitra710/contract.json
+++ b/contracts/hw.device-type/kitra710/contract.json
@@ -2,6 +2,7 @@
   "slug": "kitra710",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "RushUp Kitra 710",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/n510-tx2/contract.json
+++ b/contracts/hw.device-type/n510-tx2/contract.json
@@ -2,6 +2,7 @@
   "slug": "n510-tx2",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Aetina N510 TX2",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/nanopc-t4/contract.json
+++ b/contracts/hw.device-type/nanopc-t4/contract.json
@@ -2,6 +2,7 @@
   "slug": "nanopc-t4",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "NanoPC-T4",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/nanopi-neo-air/contract.json
+++ b/contracts/hw.device-type/nanopi-neo-air/contract.json
@@ -2,6 +2,7 @@
   "slug": "nanopi-neo-air",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Nanopi Neo Air",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/nitrogen6x/contract.json
+++ b/contracts/hw.device-type/nitrogen6x/contract.json
@@ -2,6 +2,7 @@
   "slug": "nitrogen6x",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Nitrogen 6x",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/nitrogen6xq2g/contract.json
+++ b/contracts/hw.device-type/nitrogen6xq2g/contract.json
@@ -2,6 +2,7 @@
   "slug": "nitrogen6xq2g",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Nitrogen 6X Quad 2GB",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/nitrogen8mm-dwe/contract.json
+++ b/contracts/hw.device-type/nitrogen8mm-dwe/contract.json
@@ -2,6 +2,7 @@
   "slug": "nitrogen8mm-dwe",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Nitrogen8MM DWE",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/nitrogen8mm/contract.json
+++ b/contracts/hw.device-type/nitrogen8mm/contract.json
@@ -2,6 +2,7 @@
   "slug": "nitrogen8mm",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Nitrogen8M Mini SBC",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/npe-x500-m3/contract.json
+++ b/contracts/hw.device-type/npe-x500-m3/contract.json
@@ -2,6 +2,7 @@
   "slug": "npe-x500-m3",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "NPE X500 M3",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/odroid-c1/contract.json
+++ b/contracts/hw.device-type/odroid-c1/contract.json
@@ -2,6 +2,7 @@
   "slug": "odroid-c1",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "ODroid C1",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/odroid-xu4/contract.json
+++ b/contracts/hw.device-type/odroid-xu4/contract.json
@@ -2,6 +2,7 @@
   "slug": "odroid-xu4",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["odroid-ux3","odroid-u3+"],
   "name": "ODroid XU4",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/orange-pi-lite/contract.json
+++ b/contracts/hw.device-type/orange-pi-lite/contract.json
@@ -2,6 +2,7 @@
   "slug": "orange-pi-lite",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Orange Pi Lite",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/orange-pi-one/contract.json
+++ b/contracts/hw.device-type/orange-pi-one/contract.json
@@ -2,6 +2,7 @@
   "slug": "orange-pi-one",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Orange Pi One",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/orange-pi-zero/contract.json
+++ b/contracts/hw.device-type/orange-pi-zero/contract.json
@@ -2,6 +2,7 @@
   "slug": "orange-pi-zero",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Orange Pi Zero",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/orangepi-plus2/contract.json
+++ b/contracts/hw.device-type/orangepi-plus2/contract.json
@@ -2,6 +2,7 @@
   "slug": "orangepi-plus2",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Orange Pi Plus2",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/orbitty-tx2/contract.json
+++ b/contracts/hw.device-type/orbitty-tx2/contract.json
@@ -2,6 +2,7 @@
   "slug": "orbitty-tx2",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "CTI Orbitty TX2",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/parallella/contract.json
+++ b/contracts/hw.device-type/parallella/contract.json
@@ -2,6 +2,7 @@
   "slug": "parallella",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["parallella-hdmi-resin"],
   "name": "Parallella",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/photon-nano/contract.json
+++ b/contracts/hw.device-type/photon-nano/contract.json
@@ -2,6 +2,7 @@
   "slug": "photon-nano",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "CTI Photon Nano",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/qemux86-64/contract.json
+++ b/contracts/hw.device-type/qemux86-64/contract.json
@@ -2,6 +2,7 @@
   "slug": "qemux86-64",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "QEMU x86-64",
   "data": {
     "arch": "amd64",

--- a/contracts/hw.device-type/qemux86/contract.json
+++ b/contracts/hw.device-type/qemux86/contract.json
@@ -2,6 +2,7 @@
   "slug": "qemux86",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "QEMU x86",
   "data": {
     "arch": "i386",

--- a/contracts/hw.device-type/raspberry-pi/contract.json
+++ b/contracts/hw.device-type/raspberry-pi/contract.json
@@ -2,6 +2,7 @@
   "slug": "raspberry-pi",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["raspberrypi"],
   "name": "Raspberry Pi (1, Zero, Zero W)",
   "data": {
     "arch": "rpi",

--- a/contracts/hw.device-type/raspberry-pi2/contract.json
+++ b/contracts/hw.device-type/raspberry-pi2/contract.json
@@ -2,6 +2,7 @@
   "slug": "raspberry-pi2",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["raspberrypi2"],
   "name": "Raspberry Pi 2",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/raspberrypi3-64/contract.json
+++ b/contracts/hw.device-type/raspberrypi3-64/contract.json
@@ -2,6 +2,7 @@
   "slug": "raspberrypi3-64",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Raspberry Pi 3 64bits",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/raspberrypi3/contract.json
+++ b/contracts/hw.device-type/raspberrypi3/contract.json
@@ -2,6 +2,7 @@
   "slug": "raspberrypi3",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Raspberry Pi 3",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/raspberrypi4-64/contract.json
+++ b/contracts/hw.device-type/raspberrypi4-64/contract.json
@@ -2,6 +2,7 @@
   "slug": "raspberrypi4-64",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Raspberry Pi 4 (using 64bit OS)",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/revpi-core-3/contract.json
+++ b/contracts/hw.device-type/revpi-core-3/contract.json
@@ -2,6 +2,7 @@
   "slug": "revpi-core-3",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Revolution Pi Core 3",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/skx2/contract.json
+++ b/contracts/hw.device-type/skx2/contract.json
@@ -2,6 +2,7 @@
   "slug": "skx2",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "SKX2",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/spacely-tx2/contract.json
+++ b/contracts/hw.device-type/spacely-tx2/contract.json
@@ -2,6 +2,7 @@
   "slug": "spacely-tx2",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "CTI Spacely TX2",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/srd3-tx2/contract.json
+++ b/contracts/hw.device-type/srd3-tx2/contract.json
@@ -2,6 +2,7 @@
   "slug": "srd3-tx2",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Nvidia D3 TX2",
   "data": {
     "arch": "aarch64",

--- a/contracts/hw.device-type/surface-go/contract.json
+++ b/contracts/hw.device-type/surface-go/contract.json
@@ -2,6 +2,7 @@
   "slug": "surface-go",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Microsoft Surface Go",
   "data": {
     "arch": "amd64",

--- a/contracts/hw.device-type/surface-pro-6/contract.json
+++ b/contracts/hw.device-type/surface-pro-6/contract.json
@@ -2,6 +2,7 @@
   "slug": "surface-pro-6",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Microsoft Surface Pro 6",
   "data": {
     "arch": "amd64",

--- a/contracts/hw.device-type/ts4900/contract.json
+++ b/contracts/hw.device-type/ts4900/contract.json
@@ -2,6 +2,7 @@
   "slug": "ts4900",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Technologic TS-4900",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/ts7700/contract.json
+++ b/contracts/hw.device-type/ts7700/contract.json
@@ -2,6 +2,7 @@
   "slug": "ts7700",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Technologic TS-7700",
   "data": {
     "arch": "armv5e",

--- a/contracts/hw.device-type/up-board/contract.json
+++ b/contracts/hw.device-type/up-board/contract.json
@@ -2,6 +2,7 @@
   "slug": "up-board",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "UP Board",
   "data": {
     "arch": "amd64",

--- a/contracts/hw.device-type/up-core-plus/contract.json
+++ b/contracts/hw.device-type/up-core-plus/contract.json
@@ -2,6 +2,7 @@
   "slug": "up-core-plus",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "UP Core Plus",
   "data": {
     "arch": "amd64",

--- a/contracts/hw.device-type/up-core/contract.json
+++ b/contracts/hw.device-type/up-core/contract.json
@@ -2,6 +2,7 @@
   "slug": "up-core",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "UP Core",
   "data": {
     "arch": "amd64",

--- a/contracts/hw.device-type/up-squared/contract.json
+++ b/contracts/hw.device-type/up-squared/contract.json
@@ -2,6 +2,7 @@
   "slug": "up-squared",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "UP Squared",
   "data": {
     "arch": "amd64",

--- a/contracts/hw.device-type/var-som-mx6/contract.json
+++ b/contracts/hw.device-type/var-som-mx6/contract.json
@@ -2,6 +2,7 @@
   "slug": "var-som-mx6",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": [],
   "name": "Variscite VAR-SOM-MX6",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/via-vab820-quad/contract.json
+++ b/contracts/hw.device-type/via-vab820-quad/contract.json
@@ -2,6 +2,7 @@
   "slug": "via-vab820-quad",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["vab820-quad"],
   "name": "VIA vab820",
   "data": {
     "arch": "armv7hf",

--- a/contracts/hw.device-type/zynq-xz702/contract.json
+++ b/contracts/hw.device-type/zynq-xz702/contract.json
@@ -2,6 +2,7 @@
   "slug": "zc702-zynq7",
   "version": "1",
   "type": "hw.device-type",
+  "aliases": ["zc702-zynq7"],
   "name": "Zynq zc702",
   "data": {
     "arch": "armv7hf",


### PR DESCRIPTION
Aliases are natively supported as part of the contract schema, see: https://github.com/balena-io/contrato/pull/8/files

Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>