### PR TITLE
Add "ethernet" field to connectivity and "usb" for device types

### DIFF
--- a/contracts/hw.device-type/aio-3288c/contract.json
+++ b/contracts/hw.device-type/aio-3288c/contract.json
@@ -2,15 +2,19 @@
   "slug": "aio-3288c",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["aio-3288c"],
+  "aliases": [
+    "aio-3288c"
+  ],
   "name": "AIO 3288C",
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/am571x-evm/contract.json
+++ b/contracts/hw.device-type/am571x-evm/contract.json
@@ -7,9 +7,11 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
-      "bluetooth": false
+      "bluetooth": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/apalis-imx6q/contract.json
+++ b/contracts/hw.device-type/apalis-imx6q/contract.json
@@ -2,14 +2,18 @@
   "slug": "apalis-imx6q",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["apalis-imx6"],
+  "aliases": [
+    "apalis-imx6"
+  ],
   "name": "Toradex Apalis",
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
-      "bluetooth": false
+      "bluetooth": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/artik10/contract.json
+++ b/contracts/hw.device-type/artik10/contract.json
@@ -7,9 +7,11 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
-      "bluetooth": false
+      "bluetooth": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/artik5/contract.json
+++ b/contracts/hw.device-type/artik5/contract.json
@@ -2,14 +2,18 @@
   "slug": "artik5",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["artik520"],
+  "aliases": [
+    "artik520"
+  ],
   "name": "Samsung Artik 5",
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
-      "bluetooth": true
+      "bluetooth": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/artik530/contract.json
+++ b/contracts/hw.device-type/artik530/contract.json
@@ -7,9 +7,11 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
-      "bluetooth": true
+      "bluetooth": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/artik533s/contract.json
+++ b/contracts/hw.device-type/artik533s/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/artik710/contract.json
+++ b/contracts/hw.device-type/artik710/contract.json
@@ -7,9 +7,11 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
-      "bluetooth": true
+      "bluetooth": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/asus-tinker-board-s/contract.json
+++ b/contracts/hw.device-type/asus-tinker-board-s/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/asus-tinker-board/contract.json
+++ b/contracts/hw.device-type/asus-tinker-board/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/bananapi-m1-plus/contract.json
+++ b/contracts/hw.device-type/bananapi-m1-plus/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/beagleboard-xm/contract.json
+++ b/contracts/hw.device-type/beagleboard-xm/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/beaglebone-black/contract.json
+++ b/contracts/hw.device-type/beaglebone-black/contract.json
@@ -2,15 +2,19 @@
   "slug": "beaglebone-black",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["beaglebone"],
+  "aliases": [
+    "beaglebone"
+  ],
   "name": "BeagleBone Black",
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/beaglebone-green-wifi/contract.json
+++ b/contracts/hw.device-type/beaglebone-green-wifi/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": false,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/beaglebone-green/contract.json
+++ b/contracts/hw.device-type/beaglebone-green/contract.json
@@ -6,11 +6,13 @@
   "name": "BeagleBone Green",
   "data": {
     "arch": "armv7hf",
-    "led": true,
     "hdmi": false,
+    "usb": true,
+    "led": true,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/beaglebone-pocket/contract.json
+++ b/contracts/hw.device-type/beaglebone-pocket/contract.json
@@ -6,11 +6,13 @@
   "name": "PocketBeagle",
   "data": {
     "arch": "armv7hf",
-    "led": true,
     "hdmi": false,
+    "usb": true,
+    "led": true,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/blackboard-tx2/contract.json
+++ b/contracts/hw.device-type/blackboard-tx2/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/cl-som-imx8/contract.json
+++ b/contracts/hw.device-type/cl-som-imx8/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/colibri-imx6dl/contract.json
+++ b/contracts/hw.device-type/colibri-imx6dl/contract.json
@@ -2,15 +2,19 @@
   "slug": "colibri-imx6dl",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["colibri-imx6"],
+  "aliases": [
+    "colibri-imx6"
+  ],
   "name": "Toradex Colibri",
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/coral-dev/contract.json
+++ b/contracts/hw.device-type/coral-dev/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/cybertan-ze250/contract.json
+++ b/contracts/hw.device-type/cybertan-ze250/contract.json
@@ -2,14 +2,18 @@
   "slug": "cybertan-ze250",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["ZE250"],
+  "aliases": [
+    "ZE250"
+  ],
   "name": "Cybertan ze250",
   "data": {
     "arch": "i386-nlp",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
-      "bluetooth": false
+      "bluetooth": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/etcher-pro/contract.json
+++ b/contracts/hw.device-type/etcher-pro/contract.json
@@ -7,9 +7,11 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/fincm3/contract.json
+++ b/contracts/hw.device-type/fincm3/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/firefly-rk3288/contract.json
+++ b/contracts/hw.device-type/firefly-rk3288/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/generic-aarch64/contract.json
+++ b/contracts/hw.device-type/generic-aarch64/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/generic-armv7ahf/contract.json
+++ b/contracts/hw.device-type/generic-armv7ahf/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/genericx86-64-ext/contract.json
+++ b/contracts/hw.device-type/genericx86-64-ext/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "amd64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/hummingboard/contract.json
+++ b/contracts/hw.device-type/hummingboard/contract.json
@@ -2,15 +2,21 @@
   "slug": "hummingboard",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["solidrun-imx6","cubox-i","hummingboard2"],
+  "aliases": [
+    "solidrun-imx6",
+    "cubox-i",
+    "hummingboard2"
+  ],
   "name": "Hummingboard",
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/imx6ul-var-dart/contract.json
+++ b/contracts/hw.device-type/imx6ul-var-dart/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": false,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/imx7-var-som/contract.json
+++ b/contracts/hw.device-type/imx7-var-som/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": false,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/imx8m-var-dart/contract.json
+++ b/contracts/hw.device-type/imx8m-var-dart/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/imx8mm-var-dart-nrt/contract.json
+++ b/contracts/hw.device-type/imx8mm-var-dart-nrt/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": false,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/imx8mm-var-dart-plt/contract.json
+++ b/contracts/hw.device-type/imx8mm-var-dart-plt/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": false,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/imx8mm-var-dart/contract.json
+++ b/contracts/hw.device-type/imx8mm-var-dart/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": false,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/intel-edison/contract.json
+++ b/contracts/hw.device-type/intel-edison/contract.json
@@ -2,15 +2,19 @@
   "slug": "intel-edison",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["edison"],
+  "aliases": [
+    "edison"
+  ],
   "name": "Intel Edison",
   "data": {
     "arch": "i386",
     "hdmi": false,
+    "usb": false,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": false
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/intel-nuc/contract.json
+++ b/contracts/hw.device-type/intel-nuc/contract.json
@@ -2,15 +2,19 @@
   "slug": "intel-nuc",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["nuc"],
+  "aliases": [
+    "nuc"
+  ],
   "name": "Intel NUC",
   "data": {
     "arch": "amd64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/iot2000/contract.json
+++ b/contracts/hw.device-type/iot2000/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "i386-nlp",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/jetson-nano/contract.json
+++ b/contracts/hw.device-type/jetson-nano/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/jetson-tx1/contract.json
+++ b/contracts/hw.device-type/jetson-tx1/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/jetson-tx2/contract.json
+++ b/contracts/hw.device-type/jetson-tx2/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/jetson-xavier/contract.json
+++ b/contracts/hw.device-type/jetson-xavier/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/jn30b-nano/contract.json
+++ b/contracts/hw.device-type/jn30b-nano/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/kitra520/contract.json
+++ b/contracts/hw.device-type/kitra520/contract.json
@@ -7,9 +7,11 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
-      "bluetooth": false
+      "bluetooth": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/kitra710/contract.json
+++ b/contracts/hw.device-type/kitra710/contract.json
@@ -7,9 +7,11 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
-      "bluetooth": true
+      "bluetooth": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/n510-tx2/contract.json
+++ b/contracts/hw.device-type/n510-tx2/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/nanopc-t4/contract.json
+++ b/contracts/hw.device-type/nanopc-t4/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/nanopi-neo-air/contract.json
+++ b/contracts/hw.device-type/nanopi-neo-air/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": false,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/nitrogen6x/contract.json
+++ b/contracts/hw.device-type/nitrogen6x/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/nitrogen6xq2g/contract.json
+++ b/contracts/hw.device-type/nitrogen6xq2g/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/nitrogen8mm-dwe/contract.json
+++ b/contracts/hw.device-type/nitrogen8mm-dwe/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": false,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/nitrogen8mm/contract.json
+++ b/contracts/hw.device-type/nitrogen8mm/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": false,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/npe-x500-m3/contract.json
+++ b/contracts/hw.device-type/npe-x500-m3/contract.json
@@ -7,9 +7,11 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
-      "bluetooth": true
+      "bluetooth": true,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/odroid-c1/contract.json
+++ b/contracts/hw.device-type/odroid-c1/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/odroid-xu4/contract.json
+++ b/contracts/hw.device-type/odroid-xu4/contract.json
@@ -2,15 +2,20 @@
   "slug": "odroid-xu4",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["odroid-ux3","odroid-u3+"],
+  "aliases": [
+    "odroid-ux3",
+    "odroid-u3+"
+  ],
   "name": "ODroid XU4",
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/orange-pi-lite/contract.json
+++ b/contracts/hw.device-type/orange-pi-lite/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": false,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/orange-pi-one/contract.json
+++ b/contracts/hw.device-type/orange-pi-one/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/orange-pi-zero/contract.json
+++ b/contracts/hw.device-type/orange-pi-zero/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": false,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": false,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/orangepi-plus2/contract.json
+++ b/contracts/hw.device-type/orangepi-plus2/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/orbitty-tx2/contract.json
+++ b/contracts/hw.device-type/orbitty-tx2/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/parallella/contract.json
+++ b/contracts/hw.device-type/parallella/contract.json
@@ -2,15 +2,19 @@
   "slug": "parallella",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["parallella-hdmi-resin"],
+  "aliases": [
+    "parallella-hdmi-resin"
+  ],
   "name": "Parallella",
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/photon-nano/contract.json
+++ b/contracts/hw.device-type/photon-nano/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/qemux86-64/contract.json
+++ b/contracts/hw.device-type/qemux86-64/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "amd64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/qemux86/contract.json
+++ b/contracts/hw.device-type/qemux86/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "i386",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/raspberry-pi/contract.json
+++ b/contracts/hw.device-type/raspberry-pi/contract.json
@@ -2,15 +2,19 @@
   "slug": "raspberry-pi",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["raspberrypi"],
+  "aliases": [
+    "raspberrypi"
+  ],
   "name": "Raspberry Pi (1, Zero, Zero W)",
   "data": {
     "arch": "rpi",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/raspberry-pi2/contract.json
+++ b/contracts/hw.device-type/raspberry-pi2/contract.json
@@ -2,15 +2,19 @@
   "slug": "raspberry-pi2",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["raspberrypi2"],
+  "aliases": [
+    "raspberrypi2"
+  ],
   "name": "Raspberry Pi 2",
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/raspberrypi3-64/contract.json
+++ b/contracts/hw.device-type/raspberrypi3-64/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/raspberrypi3/contract.json
+++ b/contracts/hw.device-type/raspberrypi3/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/raspberrypi4-64/contract.json
+++ b/contracts/hw.device-type/raspberrypi4-64/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/revpi-core-3/contract.json
+++ b/contracts/hw.device-type/revpi-core-3/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": true,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/skx2/contract.json
+++ b/contracts/hw.device-type/skx2/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/spacely-tx2/contract.json
+++ b/contracts/hw.device-type/spacely-tx2/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/srd3-tx2/contract.json
+++ b/contracts/hw.device-type/srd3-tx2/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/surface-go/contract.json
+++ b/contracts/hw.device-type/surface-go/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "amd64",
     "hdmi": false,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/surface-pro-6/contract.json
+++ b/contracts/hw.device-type/surface-pro-6/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "amd64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/ts4900/contract.json
+++ b/contracts/hw.device-type/ts4900/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/ts7700/contract.json
+++ b/contracts/hw.device-type/ts7700/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv5e",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false

--- a/contracts/hw.device-type/up-board/contract.json
+++ b/contracts/hw.device-type/up-board/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "amd64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/up-core-plus/contract.json
+++ b/contracts/hw.device-type/up-core-plus/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "amd64",
     "hdmi": false,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/up-core/contract.json
+++ b/contracts/hw.device-type/up-core/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "amd64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/up-squared/contract.json
+++ b/contracts/hw.device-type/up-squared/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "amd64",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": false,
-      "wifi": false
+      "wifi": false,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/var-som-mx6/contract.json
+++ b/contracts/hw.device-type/var-som-mx6/contract.json
@@ -7,10 +7,12 @@
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
       "bluetooth": true,
-      "wifi": true
+      "wifi": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/via-vab820-quad/contract.json
+++ b/contracts/hw.device-type/via-vab820-quad/contract.json
@@ -2,14 +2,18 @@
   "slug": "via-vab820-quad",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["vab820-quad"],
+  "aliases": [
+    "vab820-quad"
+  ],
   "name": "VIA vab820",
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
-      "bluetooth": true
+      "bluetooth": true,
+      "ethernet": true
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/zynq-xz702/contract.json
+++ b/contracts/hw.device-type/zynq-xz702/contract.json
@@ -2,14 +2,18 @@
   "slug": "zc702-zynq7",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": ["zc702-zynq7"],
+  "aliases": [
+    "zc702-zynq7"
+  ],
   "name": "Zynq zc702",
   "data": {
     "arch": "armv7hf",
     "hdmi": true,
+    "usb": true,
     "led": false,
     "connectivity": {
-      "bluetooth": false
+      "bluetooth": false,
+      "ethernet": true
     },
     "storage": {
       "internal": false


### PR DESCRIPTION
I am considering how to distinguish between a device having an onboard wifi/bluetooth connectivity, and if the device can support it using an external dongle, for example.

Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>