### PR TITLE
astro-tx2: Add CTI Astro TX2 G+ device type

### DIFF
--- a/contracts/hw.device-type/astro-tx2/contract.json
+++ b/contracts/hw.device-type/astro-tx2/contract.json
@@ -1,0 +1,22 @@
+{
+  "slug": "astro-tx2",
+  "version": "1",
+  "type": "hw.device-type",
+  "aliases": [],
+  "name": "CTI Astro TX2 G+",
+  "data": {
+    "arch": "aarch64",
+    "hdmi": true,
+    "led": false,
+    "connectivity": {
+      "bluetooth": true,
+      "wifi": true
+    },
+    "storage": {
+      "internal": true
+    },
+    "media": {
+      "installation": "sdcard"
+    }
+  }
+}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>