### PR TITLE
Few base images updates

### DIFF
--- a/contracts/sw.os+hw.device-type/debian+jetson-nano-emmc/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-nano-emmc/distro-config.tpl
@@ -1,3 +1,4 @@
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-nano/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-nano/distro-config.tpl
@@ -1,3 +1,4 @@
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-tx1/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-tx1/distro-config.tpl
@@ -1,3 +1,4 @@
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-tx2/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-tx2/distro-config.tpl
@@ -1,3 +1,4 @@
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit-emmc/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit-emmc/distro-config.tpl
@@ -1,3 +1,4 @@
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-xavier/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-xavier/distro-config.tpl
@@ -1,3 +1,4 @@
 RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-nano-emmc/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-nano-emmc/distro-config.tpl
@@ -1,0 +1,4 @@
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-nano/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-nano/distro-config.tpl
@@ -1,0 +1,4 @@
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-tx1/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-tx1/distro-config.tpl
@@ -1,0 +1,4 @@
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-tx2/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-tx2/distro-config.tpl
@@ -1,0 +1,4 @@
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit-emmc/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit-emmc/distro-config.tpl
@@ -1,0 +1,4 @@
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier/distro-config.tpl
@@ -1,0 +1,4 @@
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.stack/golang/contract.json
+++ b/contracts/sw.stack/golang/contract.json
@@ -4,8 +4,8 @@
   "name": "Go v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "1.14.6",
-    "versionList": "`1.14.6 (latest)`, `1.13.14`",
+    "latest": "1.15",
+    "versionList": "`1.15 (latest)`, `1.14.7`, `1.13.14`",
     "introduction": "Go (a.k.a., Golang) is a programming language first developed at Google. It is a statically-typed language with syntax loosely derived from C, but with additional features such as garbage collection, type safety, some dynamic-typing capabilities, additional built-in types (e.g., variable-length arrays and key-value maps), and a large standard library.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/golang/logo.png"
   },
@@ -28,7 +28,7 @@
   },
   "variants": [
     {
-      "version": "1.14.6",
+      "version": "1.15",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -39,7 +39,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "0018a92811aedf41d922f2896e5eeaed9c7ae48ab2395319b44704b564a3705c",
+                  "checksum": "7f284a352062d8efdbe46939c3097b1bd16194bdd8f9cfc0f1672d36b85959a3",
                   "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                   
@@ -52,7 +52,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "61059c85f637137f966fa16bac8df02ffdeea821cda858e2257bf114ee091e88",
+                  "checksum": "d0c489c9d4c746dd0aedde4135cc524094b6a5e8fbc9224005b5091d7aa9ef53",
                   "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -64,7 +64,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "6a62a006969dd325e787cb160e57f92331a97f8bd50938a66eec4e96d8665ff5",
+                  "checksum": "f8ca3ea41979569b5ac8f08f6a6e4bf8a4addd97a0b584e753684ad24c14cc61",
                   "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -76,7 +76,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "1a4ffea290e130e33cc46ce7957ee97b30a2b0dba85f5c5c8f91f614f3f5a9c5",
+                  "checksum": "2dfc4339d7dae75876c14b4125d19de5c67404110f95128263ef230b954678a1",
                   "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -88,7 +88,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "fff708036a86b71614b9fe5958840d0f280f9e440a2bc368a47fd6f1ab6a6d48",
+                  "checksum": "d0c852a7114f52218a7c5cb57cc7c309a54d82884ec138273667cb9d0e52eed7",
                   "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -114,7 +114,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "cab39cc0fdf9731476a339af9d7bcd8fc661bfa323abb1ce9d1633fb31daeb07",
+                  "checksum": "6d8914ddd25f85f2377c269ccfb359acf53adf71a42cdbf53434a7c76fa7a9bd",
                   "name": "go$GO_VERSION.linux-armv6l.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -126,7 +126,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "ddb6249d72f6f4dc213bde2cb4a66f5e72816db0606c69ccbd83adb0148912b8",
+                  "checksum": "db2c336109d1c5c57b85ffaae96f77754e252e5ff9c245ea5ff786c752a1c680",
                   "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -138,7 +138,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "5c566ddc2e0bcfc25c26a5dc44a440fcc0177f7350c1f01952b34d5989a0d287",
+                  "checksum": "2d75848ac606061efe52a8068d0e647b35ce487a15bb52272c427df485193602",
                   "name": "go$GO_VERSION.linux-amd64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -150,7 +150,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "291bccfd7d7f1915599bbcc90e49d9fccfcb0004b7c62a2f5cdf0f96a09d6a3e",
+                  "checksum": "7e18d92f61ddf480a4f9a57db09389ae7b9dadf68470d0cb9c00d734a0c57f8d",
                   "name": "go$GO_VERSION.linux-arm64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -162,7 +162,155 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "17b2c4e26bd3a82a0a44499ae2d36e3f2155d0fe2f6b9a14ac6b7c5afac3ca6a",
+                  "checksum": "68ce979083126694ceef60233f69efe870f54af24d81a120f76265107a9e9aab",
+                  "name": "go$GO_VERSION.linux-386.tar.gz",
+                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "i386" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "1.14.7",
+      "variants": [
+        {
+          "data": { "libc": "musl-libc" },
+          "requires": [
+            { "type": "sw.os", "slug": "alpine" }
+          ],
+          "variants": [
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "92f76435c57ed4de0eb5429986fe10f6b681b71e7ca3634d6ec17a6a720acdcc",
+                  "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
+                  
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "rpi" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "41dac17a1a8be6bcb84ceaef6151e788036701ed1c04bcc9c2ba8a7c0f807b00",
+                  "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "amd64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "2ac86cf64cfdafbf61f9230d2ee2ea1408294f31683b8a1240b063bdfb427952",
+                  "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "i386" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "05cb90d27c0b5a828616cc43ae90a35257b912618d89828180fab70eeeafbe6b",
+                  "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "aarch64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "4753874ad7f9c9d51b7016a1dca41ce923d8327a8213f4d0c47f58a3f682cdc3",
+                  "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "armv7hf" }
+              ]
+            }
+          ]
+        },
+        {
+          "data": { "libc": "glibc" },
+          "requires": [
+            {
+              "or": [
+                { "type": "sw.os", "slug": "debian" },
+                { "type": "sw.os", "slug": "ubuntu" },
+                { "type": "sw.os", "slug": "fedora" }
+              ]
+            }
+          ],
+          "variants": [
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "6079eb82bcf24b33dda0e32777c7fdddcc3b1ec70e374308cc8311562449b107",
+                  "name": "go$GO_VERSION.linux-armv6l.tar.gz",
+                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "rpi" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "05a408fd1c103ed9567f40e9faf7522941e60d1271a8aa5e71d523ccfbc8e965",
+                  "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "armv7hf" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "4a7fa60f323ee1416a4b1425aefc37ea359e9d64df19c326a58953a97ad41ea5",
+                  "name": "go$GO_VERSION.linux-amd64.tar.gz",
+                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "amd64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "fe5b6f6e441f3cb7b53ebf1a010bbebcb720ac98124984cfe2e51d72b8a58c71",
+                  "name": "go$GO_VERSION.linux-arm64.tar.gz",
+                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "aarch64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "2f5793f10bb6b08eedecd376aa3d594e10193c6b5cf198ada46200259ff76547",
                   "name": "go$GO_VERSION.linux-386.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }


### PR DESCRIPTION
This PR contains the following changes:
```
- Add Golang v1.5 and v1.14.7.
- Add l4t-core workaround for all Jetson images.
- Add repo.download.nvidia.com/jetson sources to Ubuntu base images.
```