### PR TITLE
jetson-xavier-nx-devkit: Add device type

### DIFF
--- a/contracts/hw.device-type/jetson-xavier-nx-devkit/contract.json
+++ b/contracts/hw.device-type/jetson-xavier-nx-devkit/contract.json
@@ -1,0 +1,23 @@
+{
+  "slug": "jetson-xavier-nx-devkit",
+  "version": "1",
+  "type": "hw.device-type",
+  "aliases": [],
+  "name": "Nvidia Jetson Xavier NX Devkit SD-CARD",
+  "data": {
+    "arch": "aarch64",
+    "hdmi": true,
+    "led": false,
+    "connectivity": {
+      "bluetooth": true,
+      "wifi": true
+    },
+    "storage": {
+      "internal": false
+    },
+    "media": {
+      "installation": "sdcard"
+    },
+    "is_private": false
+  }
+}


### PR DESCRIPTION
Add Jetson Xavier NX Devkit SD-CARD device type

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>