### PR TITLE
Base images updates

### DIFF
--- a/contracts/sw.stack/golang/contract.json
+++ b/contracts/sw.stack/golang/contract.json
@@ -4,8 +4,8 @@
   "name": "Go v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "1.15.2",
-    "versionList": "`1.15.2 (latest)`, `1.14.9`, `1.13.14`",
+    "latest": "1.15.3",
+    "versionList": "`1.15.3 (latest)`, `1.14.10`",
     "introduction": "Go (a.k.a., Golang) is a programming language first developed at Google. It is a statically-typed language with syntax loosely derived from C, but with additional features such as garbage collection, type safety, some dynamic-typing capabilities, additional built-in types (e.g., variable-length arrays and key-value maps), and a large standard library.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/golang/logo.png"
   },
@@ -28,7 +28,7 @@
   },
   "variants": [
     {
-      "version": "1.15.2",
+      "version": "1.15.3",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -39,7 +39,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "fab6dfc2013103d91ed0beddff054b7ec83049e6f1d41c9650cbd5d235adb30a",
+                  "checksum": "a325f2afb7ba3e315840dce595c680518e0d609fa52cd363ee0a3546f5c46017",
                   "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                   
@@ -52,7 +52,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "8dcb5b6360b9ef45c0523981027f59be59c47906a45be3c74c3f1614bf5552cc",
+                  "checksum": "b4ac4a534e0f490593385b5e24f3052dc42ae07abab3ec6ca30de3523b7771db",
                   "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -64,7 +64,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "8fc3d60749d09fc98559779673eec9193369a4f1149b35c85e55c3092876b4ba",
+                  "checksum": "d8daa0d78cfdff3bcb5df3f1ebd07f362720a0d46f669ff747a7e31d0e910164",
                   "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -76,7 +76,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "ffdd2f57047215dd3e6c73b482038beac8fb44f5053c2a17d8f4a41a2c87e8aa",
+                  "checksum": "f55e59fd634d021fa934ab272989df5fc61c7ff1d518ffbacd103ec216e97376",
                   "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -88,7 +88,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "4bc2f41e9747e2c27865a288cc3e1e9940b1fa908007a6202a90aa2042a856d5",
+                  "checksum": "9973c1d7bfada28b3c2362a3074bba60ceebb984f145827bbaee1bea2c08fc7d",
                   "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -114,7 +114,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c12e2afdcb21e530d332d4994919f856dd2a676e9d67034c7d6fefcb241412d9",
+                  "checksum": "aacb49968d08e222c83dea7307b4523c3ae498a5d2e91cd0e480ef3f198ffef6",
                   "name": "go$GO_VERSION.linux-armv6l.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -126,7 +126,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "51fd90c0dad4cfac5a4098bbb89ab1d55abe48bafa040299a03060c660c89dc7",
+                  "checksum": "d7954a0477a568532f9d40d506681e9c3ea4e3ddd907c15c2b17ab5835831bd3",
                   "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -138,7 +138,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "b49fda1ca29a1946d6bb2a5a6982cf07ccd2aba849289508ee0f9918f6bb4552",
+                  "checksum": "010a88df924a81ec21b293b5da8f9b11c176d27c0ee3962dc1738d2352d3c02d",
                   "name": "go$GO_VERSION.linux-amd64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -150,7 +150,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c8ec460cc82d61604b048f9439c06bd591722efce5cd48f49e19b5f6226bd36d",
+                  "checksum": "b8b88a87ada918ef5189fa5938ef4c46a4f61952a34317612aaac705f4275f80",
                   "name": "go$GO_VERSION.linux-arm64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -162,7 +162,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "5a91080469df6b91f1022bdfb0ca75e01ca50387950b13518def3d0a7f6af9f1",
+                  "checksum": "e2f4f9ccfebd38b112fe84572af44bb2fa230d605fcec84def9498095c1bd6ce",
                   "name": "go$GO_VERSION.linux-386.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -176,7 +176,7 @@
       ]
     },
     {
-      "version": "1.14.9",
+      "version": "1.14.10",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -187,7 +187,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a2a9ee3d435c9ffd7f4ac9eb065be33862d73c5af3c8bcb7d822b5275ce0059a",
+                  "checksum": "94dcab0f9415c5852fb01b365f6fd61bde3b19d98e9cceff1c57daac866e1ba7",
                   "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                   
@@ -200,7 +200,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "94cdc3e80cb1f6c500042fc4a61f022c3d5c65651b2dadf1eb2c051821950408",
+                  "checksum": "f78ec6ee7fb23d072564acdd12f04e2bccccad5142dd3ded006d8c2b0818a165",
                   "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -212,7 +212,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "e4800360ef75415401f5a93f2db24b5b2a621a42dc7e78f1ca5108df4347f3ec",
+                  "checksum": "e021d1d037524d8294059d5f611a4ca6001bfa45a9717ab709144482a9aa2e0f",
                   "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -224,7 +224,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c402fb9249c59a89e7ebd59a2b1acecb8c117300e8cb39cc4285e08de425d2bb",
+                  "checksum": "ab9ef0e35ea0d670d6704377de164d9816221411ab6989d960e68bcdd195d28d",
                   "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -236,7 +236,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "483a698560d5153e89b472a4465a9f8ed72f6f576887edabe288e0fc4ce9f87b",
+                  "checksum": "48fda80eb37b43e8bb5840f6b957203828f57d2a63d45eb3acfac49d133d549f",
                   "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -262,7 +262,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "e85dc09608dc9fc245ebc5daea0826898ac0eb0d48ed24e2300427850876c442",
+                  "checksum": "b601dbb186d786488470d73d4637c2144896bf6f499a4122bdd30f4e8dd79e70",
                   "name": "go$GO_VERSION.linux-armv6l.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -274,7 +274,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "0acbfd1a6cd7f9c1cf55256dc8d197829ed913175d4420879b486f1be537a151",
+                  "checksum": "1edba86e751297ed8f125fad087357992b6dcebdef1d201b03534d982ec1cafa",
                   "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -286,7 +286,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f0d26ff572c72c9823ae752d3c81819a81a60c753201f51f89637482531c110a",
+                  "checksum": "66eb6858f375731ba07b0b33f5c813b141a81253e7e74071eec3ae85e9b37098",
                   "name": "go$GO_VERSION.linux-amd64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -298,7 +298,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "65e6cef5c474a3514e754f6a7987c49388bb85a7b370370c1318087ac35427fa",
+                  "checksum": "30700f7a9df3148df81013bd38715acd09ca5203b8e0aafa8b985306d5e9882e",
                   "name": "go$GO_VERSION.linux-arm64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -310,155 +310,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "14982ef997ec323023a11cffe1a4afc3aacd1b5edebf70a00e17b67f888d8cdb",
-                  "name": "go$GO_VERSION.linux-386.tar.gz",
-                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "i386" }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "version": "1.13.14",
-      "variants": [
-        {
-          "data": { "libc": "musl-libc" },
-          "requires": [
-            { "type": "sw.os", "slug": "alpine" }
-          ],
-          "variants": [
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "bc1dd10928e59ec3d552c2ab1f16b581427e67614407194bd55e68ff13adb345",
-                  "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
-                  
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "rpi" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "0ec6feb0e64dea5ee4ef3e570be24dd10e5026e38af304660bc2dc27ca41c037",
-                  "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "amd64" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "a3e13da75d726183beb1a83974d53a0ca948716dc6ac000a8d14b2d5d8d3fdce",
-                  "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "i386" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "2deb9e77b6a5eac34c0cd4475c076907c594c57519b3030d73fba7d65fd2d730",
-                  "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "aarch64" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "e91cb797f2a0c056624a99e2066522272b10839e38764561fed733434ddb6882",
-                  "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "armv7hf" }
-              ]
-            }
-          ]
-        },
-        {
-          "data": { "libc": "glibc" },
-          "requires": [
-            {
-              "or": [
-                { "type": "sw.os", "slug": "debian" },
-                { "type": "sw.os", "slug": "ubuntu" },
-                { "type": "sw.os", "slug": "fedora" }
-              ]
-            }
-          ],
-          "variants": [
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "1a238daa3cd00611145d66a5577ea57bf90266443d1a2bef076ca74302a02c48",
-                  "name": "go$GO_VERSION.linux-armv6l.tar.gz",
-                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "rpi" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "2ddcc7a31f175568ef15d941d4ccea89b15ec96c72908975cbb7f04ccb49fa0d",
-                  "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "armv7hf" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "32617db984b18308f2b00279c763bff060d2739229cb8037217a49c9e691b46a",
-                  "name": "go$GO_VERSION.linux-amd64.tar.gz",
-                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "amd64" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "ee5f84e3bc0548e4963344a887f684458bec1e5a822d0d413d1c6925b784a16e",
-                  "name": "go$GO_VERSION.linux-arm64.tar.gz",
-                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "aarch64" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "537bb1769827852673ab96ce5f7676c162bba3d5394e6828733b53b4c9449c11",
+                  "checksum": "0e8e955cc80d2d7046312d16d800be82aa8ce9c5165b936348851923a75b4484",
                   "name": "go$GO_VERSION.linux-386.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }

--- a/contracts/sw.stack/node/contract.json
+++ b/contracts/sw.stack/node/contract.json
@@ -4,8 +4,8 @@
   "name": "Node.js v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "14.13.1",
-    "versionList": "`14.13.1 (latest)`, `12.19.0`, `10.22.0`",
+    "latest": "15.0.1",
+    "versionList": "`15.0.1 (latest)`, `14.15.0`, `12.19.0`, `10.23.0`",
     "introduction": "Node.js is a software platform for scalable server-side and networking applications. Node.js applications are written in JavaScript and can be run within the Node.js runtime on Mac OS X, Windows, and Linux without changes.\n\nNode.js applications are designed to maximize throughput and efficiency, using non-blocking I/O and asynchronous events. Node.js applications run single-threaded, although Node.js uses multiple threads for file and network events. Node.js is commonly used for real-time applications due to its asynchronous nature.\n\nNode.js internally uses the Google V8 JavaScript engine to execute code; a large percentage of the basic modules are written in JavaScript. Node.js contains a built-in, asynchronous I/O library for file, socket, and HTTP communication. The HTTP and socket support allows Node.js to act as a web server without additional software such as Apache.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/node/logo.png"
   },
@@ -31,7 +31,7 @@
   ],
   "variants": [
     {
-      "version": "14.13.1",
+      "version": "15.0.1",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -42,7 +42,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3b72b5cf0f2e32234c814134e2518792615ae488c42983689220115c53dad427",
+                  "checksum": "a2c592321c381609e848e791aa1841c4c3f40351c3203be77d85aa5a2964ea86",
                   "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -54,7 +54,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f63d83a9ff8ac7bfedbdc21b7d2bd9af60f550d3cc64a79e6bcf11270ccb403a",
+                  "checksum": "3a38120e75a360897301f54b950281e34e89104a1d7d8a1af70c466723a6cb66",
                   "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -66,7 +66,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "9fb76294482a8810990cd86d0a1838e06f2a9e71de599c3caab7f0f5fab3b013",
+                  "checksum": "166cf2ff6fb22ae59c3134194f5de19056ce2e0cefd4307b8ce52a4e1aa34dc6",
                   "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -78,8 +78,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c3358d285c323546d4aaaede926ab95e4d5658a2a40ce975f0602eda0c656c40",
-                  "name": "node-v$NODE_VERSION-linux-alpine-rpi.tar.gz",
+                  "checksum": "94720f16acfef5b1d6ac540ccac7d0cb5a5392a1e4d453c45ca0c703ea7a873e",
+                  "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -90,7 +90,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "535446bbbbd6da0a01c45fd52b83876804d64d08675e2eec61a95882f6a58557",
+                  "checksum": "6e730587002076442ef29fa518e4c7cfc364dac9694d42f3378bcd271a341eef",
                   "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -116,8 +116,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "012260c3eae90c5f441391ef3d8d7fee2e3a00e63909ab8fde52a8788bc37bf8",
-                  "name": "node-v$NODE_VERSION-linux-rpi.tar.gz",
+                  "checksum": "ae7c07c9096e201868deed7bcfa6bf06518ec4ac8467856817d68cb49b1cf0a1",
+                  "name": "node-v$NODE_VERSION-linux-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -128,7 +128,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "b6530873b6787049f155e4434cb0a2f6425928b2c57247419bb103fa81a10a46",
+                  "checksum": "58e488f4ce86db179a1536b789cbeb20565286ee890225e4103480faa4e2f528",
                   "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -140,7 +140,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "872b8cf72b94109276c61182f7366c8ffdfb58986428c0f57af38cf10a5194a4",
+                  "checksum": "60d1ede0ddddaf2e47addf8cfc6955909b231d02710522341f3bf611344cd79e",
                   "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -152,7 +152,142 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "5ee6da3c86591763644f40babd2bef5a2476e98ddd6f7f1c5121fc2c81d1d613",
+                  "checksum": "138ea304781fb8f7c830f5800bea61631164b304df99f5a008cc0eeaadbe6548",
+                  "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
+                  "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "aarch64" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "14.15.0",
+      "variants": [
+        {
+          "data": { "libc": "musl-libc" },
+          "requires": [
+            { "type": "sw.os", "slug": "alpine" }
+          ],
+          "variants": [
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "03d9ef30efd07192f614bead0f29dda70fb5eff0ef29591925ea330292e0b7a5",
+                  "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "amd64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "9aa99a3be21efdf0803b8db2dd609833fcebc8a49041b7fdd533c83ad0fc1e81",
+                  "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "i386" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "b494fa17f32009f3c1c2941b9ea277ff65dacb2188edbe2c0007998663b5bf2b",
+                  "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "aarch64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "6902bb8b63a68c564d9eb91bb4b15cf5b76d4e451b2f0db09ac5c64ebe380d83",
+                  "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "rpi" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "8b4b95f4f696cb9a95fbf4987b6211db69c21645f8dfc4a2dafff7bc9b5a5ad3",
+                  "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "armv7hf" }
+              ]
+            }
+          ]
+        },
+        {
+          "data": { "libc": "glibc" },
+          "requires": [
+            {
+              "or": [
+                { "type": "sw.os", "slug": "debian" },
+                { "type": "sw.os", "slug": "ubuntu" },
+                { "type": "sw.os", "slug": "fedora" }
+              ]
+            }
+          ],
+          "variants": [
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "9284fa3dc8c14ea2427ed5be465af76a03a419b6072053c089ad54207f344a8e",
+                  "name": "node-v$NODE_VERSION-linux-armv6hf.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "rpi" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "00b97b3f97d74bdbcbc77f68d692dbbb4fe30a5b16c5a197417aa73df6b5092e",
+                  "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
+                  "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "armv7hf" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "085c3b3c262fa58cbaad4f2f62eb6cea943fbbf3492ba457b5efa8f27969e04a",
+                  "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
+                  "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "amd64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "bfb59eb99ab60a673f389e8b172ab288e12c8540e0c76a0ae40d189ba5a36cec",
                   "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -301,7 +436,7 @@
       ]
     },
     {
-      "version": "10.22.0",
+      "version": "10.23.0",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -312,8 +447,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "56f4eea834215e962d752c8a52c6216ffd5c9a8da15b29bc128c1c9b8d2b20dd",
-                  "name": "node-v$NODE_VERSION-linux-alpine-rpi.tar.gz",
+                  "checksum": "973c34ab718f31cbe1aaa77a817bc8cee4c0fbfa727c061324072814a92a3678",
+                  "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -324,7 +459,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "19e6916df79781c440e4949bb8b3714c7f8a26ed34ec5cd6f32e6871205eb4d4",
+                  "checksum": "12f2d7a755d109f8429c627faf2e24f4fe294894b9c516039e94507d55b4f02f",
                   "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -336,7 +471,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "bbd56a6551865671e33d8e0879b0b5839a72528246b2559e29d7f2bae7356f4d",
+                  "checksum": "c1aca6b9ae5f5d82fbbeecf4fc2013358670667b53f371fad58a4f8468fb0348",
                   "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -348,7 +483,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "760ad85cd0e59981229dbc5ed6029b25db81dc035134cf17667ae3b41b31e6bc",
+                  "checksum": "feabbad31d5568c757cbfea3037bf851d559565b5c3c73f3727f88c890633ec1",
                   "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -360,7 +495,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "4d69be0fe4f0b01391dacd99d9c94af0cf6e46227cab4be0e393c20faac335da",
+                  "checksum": "6025ef5c27c8873c35bc151d9eeb551c9d99e6d45c54662aaf69439d0ca20de9",
                   "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -386,7 +521,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "5701c7923062b04276005c77e7cf8e99e3bb5a1d1b8cdf6a4f512b1359136470",
+                  "checksum": "3bbf3183e960a0344d505feecaa2d151cc7346b4c629f9151497441c4b7b5d0b",
                   "name": "node-v$NODE_VERSION-linux-armv6l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -398,7 +533,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c99179db48adfd77f369878573eb9b96b13007cda5af86653cd0f5a8d772fc90",
+                  "checksum": "01118226e883c69c1dc324ab42093201ae5ef46e98116abbb6acd3775b8f9c58",
                   "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -410,7 +545,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "aa7e9e1d8abcc169119bf5c56ede515689f2644ccc4d40ca0fc33756a3deb1f7",
+                  "checksum": "19cccb78f0881a78051291a50200200a0303649ee84e5489c771d3b4e4bd0e51",
                   "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -422,7 +557,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "8e59eb6865f704785a9aa53ccf9f4cb10412caaf778cee617241a0d0684e008d",
+                  "checksum": "d66f4912a0cb84678124d9a311bee7b204665fc62f83b0fc0d10b2f385feb524",
                   "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -434,7 +569,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "2237c1b2e4d77b5c23d50e59df6fb542527b698c0d4dfee78e6a613ef2c9612f",
+                  "checksum": "004fdc90ab34138ecb690d80b5490371f7d7dbeb7c6547e626017cd0433a30fe",
                   "name": "node-v$NODE_VERSION-linux-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }


### PR DESCRIPTION
This PR contains the following changes:
- Add Golang v1.15.3 and v1.14.10.
- Add node v15.0.1 v14.15.0 and v10.23.0.