### PR TITLE
Few base images updates

### DIFF
--- a/contracts/sw.blob/qemu/contract.json
+++ b/contracts/sw.blob/qemu/contract.json
@@ -10,12 +10,12 @@
   },
   "variants": [
     {
-      "version": "4.0.0+balena2-arm",
+      "version": "5.2.0+balena-arm",
       "assets": {
         "bin": {
           "name": "qemu-arm-static",
           "url": "file://./assets/qemu-arm-static",
-          "checksum": "66cea7aaadbc3767e38ce92fc6016b2be66fe1e35f038a15a117c389f75b03b8",
+          "checksum": "a63a15f11afba41e62721e42fc83a835fc34340c6b08c1ddad538d30af857437",
           "main": "qemu-arm-static"
         }
       },
@@ -29,12 +29,12 @@
       ]
     },
     {
-      "version": "4.0.0+balena2-aarch64",
+      "version": "5.2.0+balena-aarch64",
       "assets": {
         "bin": {
           "name": "qemu-aarch64-static",
           "url": "file://./assets/qemu-aarch64-static",
-          "checksum": "87bab787ce9ab25ff36bc23dcc674431ddf801242ab62daa5a3c6606d7d040d2",
+          "checksum": "1645d4192dfa7bb60d4910a91694b383357cd3f77031bcc732c742bf642057c9",
           "main": "qemu-aarch64-static"
         }
       },

--- a/contracts/sw.stack/golang/contract.json
+++ b/contracts/sw.stack/golang/contract.json
@@ -4,8 +4,8 @@
   "name": "Go v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "1.15.6",
-    "versionList": "`1.15.6 (latest)`, `1.14.13`",
+    "latest": "1.15.7",
+    "versionList": "`1.15.7 (latest)`, `1.14.14`",
     "introduction": "Go (a.k.a., Golang) is a programming language first developed at Google. It is a statically-typed language with syntax loosely derived from C, but with additional features such as garbage collection, type safety, some dynamic-typing capabilities, additional built-in types (e.g., variable-length arrays and key-value maps), and a large standard library.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/golang/logo.png"
   },
@@ -28,7 +28,7 @@
   },
   "variants": [
     {
-      "version": "1.15.6",
+      "version": "1.15.7",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -39,7 +39,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f9edfd0b82412a549a0752e920b0364d0c6abba624f801c275f123f07f6f8e67",
+                  "checksum": "e71eb687e01399d751e137315acb1595155fb395d0ca8d2f223006ae525c11b6",
                   "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                   
@@ -52,7 +52,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "d7f723c08cbed386663e09d9edc71bbb0b8357a40ab8c4d906711aab700df33d",
+                  "checksum": "0af18e2eccac22682c780a46af23109f319adb1833d1d8d277a564d2cf275a3a",
                   "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -64,7 +64,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "85471d95c2a913ff547b59432a594712f9b9d9e3ba3c87e4fda940166a2e3a56",
+                  "checksum": "29271a178e4e61dbc35523e693c7e0e60fecfd2cbb268029cc9e5b34be54126d",
                   "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -76,7 +76,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "10290f048f0e1c667b1c3ed9b2bedc8d028b5d55e3b9101bda5b1cf6fb66ee7d",
+                  "checksum": "2887829d7c28dd15de15c2486b5a8901f6e3084667b7ff06607d90e839d077ff",
                   "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -88,7 +88,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "0b562d6a6d9f9214c9ab9a0df43da88c6864136f0bd0fa4067d12f87d52580d5",
+                  "checksum": "38f7e68aa41fed0d3a8b85c4d3e8fe558203452e8ff4148be7e4784ccccb0aee",
                   "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -114,7 +114,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "40ba9a57764e374195018ef37c38a5fbac9bbce908eab436370631a84bfc5788",
+                  "checksum": "8ab192799a191eb3752079ab17efff12d1d7dd0e965cf84dcbf08d55542e27d3",
                   "name": "go$GO_VERSION.linux-armv6l.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -126,7 +126,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "7f60787d9d94ed040e2d58f7715a4dc1cdb9f9160504aec810712a7e20446bb7",
+                  "checksum": "16da0e296dabb6c1199ccaa2de1a83e679ae2512263f6e05923319f4903beac1",
                   "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -138,7 +138,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3918e6cc85e7eaaa6f859f1bdbaac772e7a825b0eb423c63d3ae68b21f84b844",
+                  "checksum": "0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3",
                   "name": "go$GO_VERSION.linux-amd64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -150,7 +150,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f87515b9744154ffe31182da9341d0a61eb0795551173d242c8cad209239e492",
+                  "checksum": "bca4af0c20f86521dfabf3b39fa2f1ceeeb11cebf7e90bdf1de2618c40628539",
                   "name": "go$GO_VERSION.linux-arm64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -162,7 +162,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "ad187f02158b9a9013ef03f41d14aa69c402477f178825a3940280814bcbb755",
+                  "checksum": "519e5d7518376bc6b87afc04f16e72db66d9bc08641d9b4385ecf1f30e55e64c",
                   "name": "go$GO_VERSION.linux-386.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -176,7 +176,7 @@
       ]
     },
     {
-      "version": "1.14.13",
+      "version": "1.14.14",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -187,7 +187,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "30f4e2568652999816e9b5e7bc277aca94da584f7042114e68d5eff154004c69",
+                  "checksum": "bb079ea7132a0e4b621f8462868ef5a84d6223e37626a3b7b90842ef70d4bf6a",
                   "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                   
@@ -200,7 +200,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "4b41051cdd5871f51c56841f196d450b2606ea185dc9a5274330c3cf1d39f415",
+                  "checksum": "e777a0e52081692a4649590671ddb147412fa4e1cd7de2d1372ee4a7fae569e6",
                   "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -212,7 +212,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "900c70210366e4256962ad11ee11c6ee47048d4dd9a4b1f4ffaca2948fd30872",
+                  "checksum": "0261b43991f9ca4ffbf8d28b8be1b2ed50125c85a0ef5178e3adf454b0afc81a",
                   "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -224,7 +224,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "160ad7a87f7f5e5e0843f0d5cf13bc62f17d18a2dff2d1f8c9be35f69d482613",
+                  "checksum": "aefed1100ed95b55e3c1c39b54d38176d2adf77af0374a9af1a436c6ccd1e36f",
                   "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -236,7 +236,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "8ed9ed68ffcbf708850ea06bec03e601303067ee919467a1b5b096ca779188d7",
+                  "checksum": "e692f873293bde118580872c945b370229a9483bb75eb733a035fe09c95c1374",
                   "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -262,7 +262,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "cee8785fad978693c7b68ea635e76412a0a44917c3d58efa82b2edbf538a2868",
+                  "checksum": "e4d614c23b77a367becaeac3032cf4911793363a33efa299d29440be3d66234b",
                   "name": "go$GO_VERSION.linux-armv6l.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -274,7 +274,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "53c5236a76730f6487052fa1a629d6f5efdde6341cfc2e0544b0b28aefc27708",
+                  "checksum": "93a87bdde7d5dd8c7ba0570fd811cebdfb988a6393f5f660f4595566120e0620",
                   "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -286,7 +286,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "bfea0c8d7b70c1ad99b0266b321608db57df75820e8f4333efa448a43da01992",
+                  "checksum": "6f1354c9040d65d1622b451f43c324c1e5197aa9242d00c5a117d0e2625f3e0d",
                   "name": "go$GO_VERSION.linux-amd64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -298,7 +298,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "445b719ebf46d8825360dabad65226db154ca8053de60609bc20f80a17452cbb",
+                  "checksum": "511d764197121f212d130724afb9c296f0cb4a22424e5ae956a5cc043b0f4a29",
                   "name": "go$GO_VERSION.linux-arm64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -310,7 +310,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a168c7e03e305d33a5651acb5bfdbfb5141053a0d98f06af3e1e5081167af963",
+                  "checksum": "b08e088ba99134035782c71aeaf139f36d2306eb88eddc22c1278b8b446f157e",
                   "name": "go$GO_VERSION.linux-386.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }

--- a/contracts/sw.stack/node/contract.json
+++ b/contracts/sw.stack/node/contract.json
@@ -4,8 +4,8 @@
   "name": "Node.js v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "15.6.0",
-    "versionList": "`15.6.0 (latest)`, `14.15.4`, `12.20.1`, `10.23.1`",
+    "latest": "15.7.0",
+    "versionList": "`15.7.0 (latest)`, `14.15.4`, `12.20.1`, `10.23.1`",
     "introduction": "Node.js is a software platform for scalable server-side and networking applications. Node.js applications are written in JavaScript and can be run within the Node.js runtime on Mac OS X, Windows, and Linux without changes.\n\nNode.js applications are designed to maximize throughput and efficiency, using non-blocking I/O and asynchronous events. Node.js applications run single-threaded, although Node.js uses multiple threads for file and network events. Node.js is commonly used for real-time applications due to its asynchronous nature.\n\nNode.js internally uses the Google V8 JavaScript engine to execute code; a large percentage of the basic modules are written in JavaScript. Node.js contains a built-in, asynchronous I/O library for file, socket, and HTTP communication. The HTTP and socket support allows Node.js to act as a web server without additional software such as Apache.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/node/logo.png"
   },
@@ -31,7 +31,7 @@
   ],
   "variants": [
     {
-      "version": "15.6.0",
+      "version": "15.7.0",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -42,7 +42,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "890348f2a219bce287855ecdfbd6c8cdb3be24e0ee10d09986c5bda0d5ae955c",
+                  "checksum": "ee16f325cb02b0f527f1957e67eebef08297e9063a4aa868b1a721d9ae4e0380",
                   "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -54,7 +54,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f501f0e1ae8200d808ec3d3e2e8703b1085f297beb3e2832cb1d687bf545ffb7",
+                  "checksum": "8152df3cd975576bac9d671ccb2e2f88609a6aa4ecc171e65472e99f451c0efc",
                   "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -66,7 +66,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "37fa5575c5098f158a3fff75866555bcf9089ff9369f377c1778cdeffe3ca483",
+                  "checksum": "5b49f41f5a656f6b28e05aa8e1ee9e281b1b2fc523cada8fb19155eb1df4efcb",
                   "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -78,7 +78,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a1665c1c150da181f7641ee79ffceeb2b7f313487b61d3ae6cb43e2746f8659b",
+                  "checksum": "332e5d36dd483b44596c5aef55863dbf60c4cd9dff04cbdae759798f508c22ea",
                   "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -90,7 +90,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "084ad9e36676f5c65d932546623ba9cf5d7a329902e40f77a3b5b7e3485be841",
+                  "checksum": "73984242011b816117126c546702a7892b0ddd39cd51f672445b430161e2b903",
                   "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -116,7 +116,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "234871415c54174f91764f332a72631519a6af7b1a87797ad7c729855182f9cd",
+                  "checksum": "aa65f287bfe060321ee5e0b4f7134bd17690abb911c6fc1173ddbedddbf2c060",
                   "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -128,7 +128,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a8b42f6f174f857b9369858b63ff136ed5b9072336e6df9f0208eddde13897dc",
+                  "checksum": "8081794dc8a6a1dd46045ce5a921e227407dcf7c17ee9d1ad39e354b37526f5c",
                   "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -140,7 +140,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "b0660398fe590f8588431a787e9b032c7271a2fa88306c7a26e751571df998e4",
+                  "checksum": "72853eb858a93d53b0758b86eea0d466296ab275fbb73f2f4d40fad6cd1a0ff9",
                   "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -152,7 +152,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "4e569e9f9f8d15f7e4a358d373fae55e365b96b5a7dfe6ac5d7d4df64f18645f",
+                  "checksum": "354f239061890b643d4a661a7bb4a6b55aaba6cdd55dfeef1bafe14f67e126c3",
                   "name": "node-v$NODE_VERSION-linux-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }


### PR DESCRIPTION
This PR contains the following changes:
```
- Update QEMU to v5.2.0+balena.
- Add node v15.7.0.
- Add Go v1.15.7 and 1.14.14.
```