### PR TITLE
jetson-xaviers: Update repositories to 32.4

### DIFF
--- a/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit-emmc/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit-emmc/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-xavier/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-xavier/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit-emmc/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit-emmc/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall


### PR DESCRIPTION
We updated the hostOS to 32.4.4 in BalenaOS
2.67.3 for the Jetson Xavier boards, let's switch to
the newer container packages now.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>