### PR TITLE
device: Update name for Floyd Nano

### DIFF
--- a/contracts/hw.device-type/floyd-nano/contract.json
+++ b/contracts/hw.device-type/floyd-nano/contract.json
@@ -3,7 +3,7 @@
   "version": "1",
   "type": "hw.device-type",
   "aliases": [],
-  "name": "Floyd Nano BB02A",
+  "name": "Floyd Nano BB02A eMMC",
   "assets": {
     "logo": {
       "url": "./floyd-nano.svg",


### PR DESCRIPTION
We've updated the name in the coffee file
for this device type to show that this device
type is based on a eMMC Nano module. Let's update
the name here too.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>