### PR TITLE
Few base images updates

### DIFF
--- a/contracts/sw.stack/golang/contract.json
+++ b/contracts/sw.stack/golang/contract.json
@@ -4,8 +4,8 @@
   "name": "Go v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "1.16",
-    "versionList": "`1.6 (latest)`, `1.15.8`, `1.14.14`",
+    "latest": "1.16.3",
+    "versionList": "`1.16.3 (latest)`, `1.15.11`, `1.14.14`",
     "introduction": "Go (a.k.a., Golang) is a programming language first developed at Google. It is a statically-typed language with syntax loosely derived from C, but with additional features such as garbage collection, type safety, some dynamic-typing capabilities, additional built-in types (e.g., variable-length arrays and key-value maps), and a large standard library.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/golang/logo.png"
   },
@@ -28,7 +28,7 @@
   },
   "variants": [
     {
-      "version": "1.16",
+      "version": "1.16.3",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -39,7 +39,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "b5636bf85520840fdb9993a8f27e65b0db361c6b7a2a694d3392e9892878fa19",
+                  "checksum": "d235bfc0aeed43fc46ba644cef94e280fd08a65ec5881b9c6a78189c35828b09",
                   "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                   
@@ -52,7 +52,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "2fb4f266982a32f1433a1c0b011fb98b46a1b56ede3a0310c9f361969fc4e9cd",
+                  "checksum": "10d1c63534be387026f37a3ac3ed00c7258dfbc3ed40255956bc736cf8b3bf3b",
                   "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -64,7 +64,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "d8d44fbc837e358c8f03c94d18d79e08a388b16af9e64db3e6833fd35750019f",
+                  "checksum": "f01da465a37f3360ce0126ef7847de5d50bb16eaf4578361dca653707c0068fa",
                   "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -76,7 +76,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "56c25d13821ff03c6ed1045568964fe4ffc912b1e212a6700719401a72155555",
+                  "checksum": "d4b5a5116b9d29e1b1bf4547edd03ee8c913a6a511fb05395cdc23a26ab57ff1",
                   "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -88,7 +88,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "e5ec1504696d3484c0161fe3a0bbd37179c50cd4856b5d492a282a767e45a5ad",
+                  "checksum": "82d3d01d1f341b3afb21b1c650fe7edc6b1b4757bfef78a46a39faa4ee411b8d",
                   "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -114,7 +114,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "d1d9404b1dbd77afa2bdc70934e10fbfcf7d785c372efc29462bb7d83d0a32fd",
+                  "checksum": "0dae30385e3564a557dac7f12a63eedc73543e6da0f6017990e214ce8cc8797c",
                   "name": "go$GO_VERSION.linux-armv6l.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -126,7 +126,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "5d2c637632fc23139c992e7f5adce1e46bccebd5a43fc90f797050ae71f46ab9",
+                  "checksum": "0cfbfa848a1ab81e2aa2dd257c2b3572c3637d32562b1eaa6aeadb2909911606",
                   "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -138,7 +138,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2",
+                  "checksum": "951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2",
                   "name": "go$GO_VERSION.linux-amd64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -150,7 +150,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098",
+                  "checksum": "f4e96bbcd5d2d1942f5b55d9e4ab19564da4fad192012f6d7b0b9b055ba4208f",
                   "name": "go$GO_VERSION.linux-arm64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -162,7 +162,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "ea435a1ac6d497b03e367fdfb74b33e961d813883468080f6e239b3b03bea6aa",
+                  "checksum": "48b2d1481db756c88c18b1f064dbfc3e265ce4a775a23177ca17e25d13a24c5d",
                   "name": "go$GO_VERSION.linux-386.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -176,7 +176,7 @@
       ]
     },
     {
-      "version": "1.15.8",
+      "version": "1.15.11",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -187,7 +187,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "077b921f01c8b82ea0fcde1f5106ab9369af9595362fcaaae057a6f1f0db3868",
+                  "checksum": "fa4101336d9fa0e0908d898c45db80f7cf782112adc77d8e2d85536c21112bc4",
                   "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -199,7 +199,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "5237f65d18a7d139a13635a5ae2283c42b39cb68e7210b96a22d8958f04d12b7",
+                  "checksum": "34461bd1eebacd268bca32a27581a0b5dd177000719228641864c421626ca6e6",
                   "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -211,7 +211,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "7f81c331f301c413a7f5c57c9380c6be9ac701fddd653a08803dc820317fb7f0",
+                  "checksum": "f4b63996b23199c4f38b1cf412ea9c42009c4b36fab9469134616e9f9c402836",
                   "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -223,7 +223,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c95d3deeae1a3f305ccbc9e3a661241a415b663a96f44fea373fa563c20689f2",
+                  "checksum": "f944eac62687471e30c4183d7b91cd33cf55a8a84d49176a075e01bfc19b4eb0",
                   "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -235,7 +235,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "abce37028d563a17fb5107f17003d164ce1b587fafba33c268bd350568ab736c",
+                  "checksum": "e460a686d088a08244e6e360ce70f957854c74d7f82d8fce91a1bf3b43c54436",
                   "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -261,7 +261,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "708c398cb9e5029cfd5b654370978bf0e797d4d4a71153c06c7378db7e249a53",
+                  "checksum": "dba11ed018fc7b5774ca996c4bdb847f8f9535cdc4932eb09a43c390813af4c9",
                   "name": "go$GO_VERSION.linux-armv6l.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -273,7 +273,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "bde22202576c3920ff5646fb1d19877cedc19501939d6ccd7b16ff89071abd0a",
+                  "checksum": "f5253eb04ed6b92e49cb0cbc57a80b4777ce27c6590e05a5c91095870e8632a0",
                   "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -285,7 +285,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b",
+                  "checksum": "8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec",
                   "name": "go$GO_VERSION.linux-amd64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -297,7 +297,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "0e31ea4bf53496b0f0809730520dee98c0ae5c530f3701a19df0ba0a327bf3d2",
+                  "checksum": "bfc8f07945296e97c6d28c7999d86b5cab51c7a87eb2b22ca6781c41a6bb6f2d",
                   "name": "go$GO_VERSION.linux-arm64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -309,155 +309,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a0cc9df6d04f89af8396278d171087894a453a03a950b0f60a4ac18b480f758f",
-                  "name": "go$GO_VERSION.linux-386.tar.gz",
-                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "i386" }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "version": "1.14.14",
-      "variants": [
-        {
-          "data": { "libc": "musl-libc" },
-          "requires": [
-            { "type": "sw.os", "slug": "alpine" }
-          ],
-          "variants": [
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "bb079ea7132a0e4b621f8462868ef5a84d6223e37626a3b7b90842ef70d4bf6a",
-                  "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
-                  
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "rpi" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "e777a0e52081692a4649590671ddb147412fa4e1cd7de2d1372ee4a7fae569e6",
-                  "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "amd64" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "0261b43991f9ca4ffbf8d28b8be1b2ed50125c85a0ef5178e3adf454b0afc81a",
-                  "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "i386" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "aefed1100ed95b55e3c1c39b54d38176d2adf77af0374a9af1a436c6ccd1e36f",
-                  "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "aarch64" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "e692f873293bde118580872c945b370229a9483bb75eb733a035fe09c95c1374",
-                  "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "armv7hf" }
-              ]
-            }
-          ]
-        },
-        {
-          "data": { "libc": "glibc" },
-          "requires": [
-            {
-              "or": [
-                { "type": "sw.os", "slug": "debian" },
-                { "type": "sw.os", "slug": "ubuntu" },
-                { "type": "sw.os", "slug": "fedora" }
-              ]
-            }
-          ],
-          "variants": [
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "e4d614c23b77a367becaeac3032cf4911793363a33efa299d29440be3d66234b",
-                  "name": "go$GO_VERSION.linux-armv6l.tar.gz",
-                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "rpi" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "93a87bdde7d5dd8c7ba0570fd811cebdfb988a6393f5f660f4595566120e0620",
-                  "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "armv7hf" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "6f1354c9040d65d1622b451f43c324c1e5197aa9242d00c5a117d0e2625f3e0d",
-                  "name": "go$GO_VERSION.linux-amd64.tar.gz",
-                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "amd64" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "511d764197121f212d130724afb9c296f0cb4a22424e5ae956a5cc043b0f4a29",
-                  "name": "go$GO_VERSION.linux-arm64.tar.gz",
-                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "aarch64" }
-              ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "b08e088ba99134035782c71aeaf139f36d2306eb88eddc22c1278b8b446f157e",
+                  "checksum": "2de51fc6873d8b688d7451cfc87443ef49404af98bbab9c8a36fb6c4bc95e4de",
                   "name": "go$GO_VERSION.linux-386.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }

--- a/contracts/sw.stack/node/contract.json
+++ b/contracts/sw.stack/node/contract.json
@@ -4,8 +4,8 @@
   "name": "Node.js v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "15.10.0",
-    "versionList": "`15.10.0 (latest)`, `14.16.0`, `12.21.0`, `10.24.0`",
+    "latest": "15.14.0",
+    "versionList": "`15.14.0 (latest)`, `14.16.1`, `12.21.1`, `10.24.1`",
     "introduction": "Node.js is a software platform for scalable server-side and networking applications. Node.js applications are written in JavaScript and can be run within the Node.js runtime on Mac OS X, Windows, and Linux without changes.\n\nNode.js applications are designed to maximize throughput and efficiency, using non-blocking I/O and asynchronous events. Node.js applications run single-threaded, although Node.js uses multiple threads for file and network events. Node.js is commonly used for real-time applications due to its asynchronous nature.\n\nNode.js internally uses the Google V8 JavaScript engine to execute code; a large percentage of the basic modules are written in JavaScript. Node.js contains a built-in, asynchronous I/O library for file, socket, and HTTP communication. The HTTP and socket support allows Node.js to act as a web server without additional software such as Apache.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/node/logo.png"
   },
@@ -31,7 +31,7 @@
   ],
   "variants": [
     {
-      "version": "15.10.0",
+      "version": "15.14.0",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -42,7 +42,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3dc57a8598e098bd9960c79fb78b2e477cb8b5ac284905075c17036a100fb950",
+                  "checksum": "6cc1d9e34350a838117de88d73c368b0eb2c1181cb62c0474fade778f20646ad",
                   "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -54,7 +54,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a5d9f246865c979575b25af819187c6a9b90226a63ac6a43e341c3b47ea1ebd9",
+                  "checksum": "3de92ce6126fb78dcee7bcf161541751cba74fa2f0cf592914519c93d45fdbea",
                   "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -66,8 +66,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "6de30981f9056e3f653cb45fc037fcc70b25a3e204a9a1ad32a6e0faba74e5be",
-                  "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
+                  "checksum": "1dec2f32770b6c864c5f2c59861d91547010deb63adff2c0298a8c150fd7e3f8",
+                  "name": "node-v$NODE_VERSION-linux-aarch64-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -78,8 +78,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "66b545108a657812717a2e2b953b337373be076b1fd172e6fc54599a24878a46",
-                  "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
+                  "checksum": "813641fa7fb4110dd6357f3831600d0249686d313819fea3d2ce12c9976cf5d4",
+                  "name": "node-v$NODE_VERSION-linux-armv6hf-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -90,8 +90,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c47968a20a344736c55b5386ffde1e875e842f2b7e9ebbbcd8e1acd7de22f1d5",
-                  "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
+                  "checksum": "24a72c4d594d5d6bf2e6399c2d0f938560c1a19eda33f1639b3c83cf9608495d",
+                  "name": "node-v$NODE_VERSION-linux-armv7hf-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -116,7 +116,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "ca27a48dd9233b00c49b37a07751395657d4e454ebfa5066a6371e5f6c9969cf",
+                  "checksum": "1cef461a73a124dd3f212e2b8230638f4d16b5cc0915425ffad8aabac050d9fb",
                   "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -128,7 +128,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "31554d9b2de47948a364a007031c635d3943c303e50703b5f4c41a5eead07737",
+                  "checksum": "23f8adb7afbd9969f0f9b8b2da0ba3e0a9db57c547aa0c5e0885f0b2aae6081c",
                   "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -140,7 +140,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a9f8c807ec31ed24fe6e0b2d002ce2d1b9f20b7e23a0efe10679331a44b30dba",
+                  "checksum": "6d5e0074fe4a45d444bc581aa1fd7ce7081b8491b0f785414a6e5cc30c42854a",
                   "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -152,7 +152,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3ab9fab3c9bad87a783c906adf6ad16c23799ba66ea1b7155898fb558c13ef8c",
+                  "checksum": "d06dda71ba4de25643eaa49c5c5fc1701b55edc0231dfba09ee23277877441e3",
                   "name": "node-v$NODE_VERSION-linux-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -166,7 +166,7 @@
       ]
     },
     {
-      "version": "14.16.0",
+      "version": "14.16.1",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -177,7 +177,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "74a2857b06b800f7acc1831f02d5a2ee6d27d9b28699a938396caf669def10b8",
+                  "checksum": "01421c819198edabcc2e32abe416f6359f87fd5f2c5dfc3daa791f303dc53bac",
                   "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -189,7 +189,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c89eb6e1b9282cec8be13e3fdf409ea528df6b25a3dab7cc831ce805c6ca697a",
+                  "checksum": "4b814754e879808b46025e9e6c82bde72d1d273ac0344e699062040c45f1dbc8",
                   "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -201,8 +201,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "64a3d9619779ce10e55bf80071b370f538235548b8d3eeaf99a3730e952aca79",
-                  "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
+                  "checksum": "bfcd2fd8fd233bbdd1873f3e73637a21d5f16bfb1b6e56b2666e132c02df46f6",
+                  "name": "node-v$NODE_VERSION-linux-aarch64-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -213,8 +213,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a6c09e134096610df1f041c23c2cd8ea03002fa8c329a2b6f06cc51ee541f2cb",
-                  "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
+                  "checksum": "24ae4ba290f5711616d6257f193e07a658bc58a5294775430243ab1c21a74d24",
+                  "name": "node-v$NODE_VERSION-linux-armv6hf-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -225,8 +225,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "0ae0d3668eb409e09d006a93e6194e39b28b7576eee29dc779aa9dc9a2f7a88a",
-                  "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
+                  "checksum": "0d7d74264cbd457d1f54e4dcb6407a4b4b4602055d66e0a2cdec8bd635af8f59",
+                  "name": "node-v$NODE_VERSION-linux-armv7hf-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -251,7 +251,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "b5386ea1235f983d2a826abc66f86156cfb761f215e0cff0092620c036e93623",
+                  "checksum": "8471889a96bb8007407e97902a9cc6d230e3bac855f915ec6e04b500bcd0a916",
                   "name": "node-v$NODE_VERSION-linux-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -263,7 +263,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a64860a02e4b692d262d453952cae99a3c9842d3fc90336b54ca03e990c780b8",
+                  "checksum": "54efe997dbeff971b1e39c8eb910566ecb68cfd6140a6b5c738265d4b5842d24",
                   "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -275,7 +275,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "7212031d7468718d7c8f5e1766380daaabe09d54611675338e7a88a97c3e31b6",
+                  "checksum": "068400cb9f53d195444b9260fd106f7be83af62bb187932656b68166a2f87f44",
                   "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -287,7 +287,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "2b78771550f8a3e6e990d8e60e9ade82c7a9e2738b6222e92198bcd5ea857ea6",
+                  "checksum": "58cb307666ed4aa751757577a563b8a1e5d4ee73a9fac2b495e5c463682a07d1",
                   "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -301,7 +301,7 @@
       ]
     },
     {
-      "version": "12.21.0",
+      "version": "12.22.1",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -314,8 +314,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "68b6cff3667c4a24a87d4cb06b42e43fd6af21ebb83bf0bba8b7ad63b01e2dd8",
-                  "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
+                  "checksum": "97d183a9c0f83d29f570704cc67e9623f590692320d1f4c66890c51075794417",
+                  "name": "node-v$NODE_VERSION-linux-armv6hf-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -326,7 +326,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "d7a9380d330b00cb9b1dfa5b243e705bf164c51337b8e600be38b17afc4132ce",
+                  "checksum": "d0768ea110aad3d9158016231052cc786fb62893003402bc5dc5faa88106a60f",
                   "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -338,7 +338,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "ef4d6d53efcb301cfd3f81edd46d59585b2df226837d9b2c0bd21662046d4c59",
+                  "checksum": "10e508d7eb35b3bc3e0a741a3c367f46933c48e378a0dd0df86d2c59709bbd87",
                   "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -350,8 +350,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "70273118c1e630b4d7d5c3aac3247740478d135e728f8c6a1a0d3beb5b0fa6dc",
-                  "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
+                  "checksum": "2d142f5db920e65022c7affed2dfcfb4abe6f5448f29f909e0f9d608979a7bc1",
+                  "name": "node-v$NODE_VERSION-linux-aarch64-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -362,8 +362,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "57144b1f4b7c25864a27d6939ba990358d24aee1bac1420f2c94903a48a49634",
-                  "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
+                  "checksum": "e9674e7b4236df2d7f2f852209e1903911c3bb17bf716c070dfe0605751fb412",
+                  "name": "node-v$NODE_VERSION-linux-armv7hf-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -388,7 +388,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "6edc31a210e47eb72b0a2a150f7fe604539c1b2a45e8c81d378ac9315053a54f",
+                  "checksum": "1bc056e1fef1c83059235d927edea2c1a2eee91ce654f45369a2af95c041e198",
                   "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -400,7 +400,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "ab121de3c472d76ec425480b0594e43109ee607bd57c3d5314bdb65fa816bf1c",
+                  "checksum": "d315c5dea4d96658164cdb257bd8dbb5e44bdd2a7c1d747841f06515f23a0042",
                   "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -412,7 +412,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "5748bfc5bbf7d9c1c8e79bd4f71d8f049c7fc7bc5b52e04685633319843c4f93",
+                  "checksum": "917c582b7f7ae5ff8b2d97e05d00598011f9fbfcc4f76952da3ed477405c9c1a",
                   "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -426,7 +426,7 @@
       ]
     },
     {
-      "version": "10.24.0",
+      "version": "10.24.1",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -439,8 +439,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "ed1a6b64b97d85c7e5f7f0eb1d7bc2c50f7dff7bd5b98c9a3be62eaed6d24bce",
-                  "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
+                  "checksum": "18764300250f16f93c03f86e6811ddc862c6667e9433b3f3a6fa0c005661c217",
+                  "name": "node-v$NODE_VERSION-linux-armv6hf-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -451,7 +451,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "b183ec53c3a0c30e3bd9df9f200b9d1545eaea92da2cafe4f7f6113867d41696",
+                  "checksum": "0defc54cc873f8e5b3aa12fd577e71faa97b93a4ed5c841beac0904bde78c2cb",
                   "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -463,7 +463,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "986ffdfa64637979c4fe58659938711c2d046c95fd5344072dd795aa620b1698",
+                  "checksum": "36535cb32c6da847e1625d2d1337e29b05ecd064993fe0d31e67f0930c5c6bc7",
                   "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -475,8 +475,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "16cc431995b83eb0650c103dbe2eb9e1db49288727bdbf5fa0369f78d371e71f",
-                  "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
+                  "checksum": "00c56aa0fb525eb75243697d19b5c0cabe69dd0092c2017772234a310d10407a",
+                  "name": "node-v$NODE_VERSION-linux-aarch64-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -487,8 +487,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": " f001a8039bd820574122179d7adc484747ec6944431d2e345ca6ecba266e4150",
-                  "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
+                  "checksum": " dc4aeb1ea353c5f500f35bb838de7799be9bce801c903ffb0af9c014bfc3d066",
+                  "name": "node-v$NODE_VERSION-linux-armv7hf-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -513,7 +513,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "5a5dcc02bfd0ddcbeb2ef68f116bb72e416149f15f12767864bde77edd7f39d1",
+                  "checksum": "cf19f1965bca6b4ade9396e31f9490448ded2402713fdfe2d43410da037d9b5c",
                   "name": "node-v$NODE_VERSION-linux-armv6l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -525,7 +525,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "02feb052d0e1eb77c9beea5cfe3b67b90d5209ab509797f4f6c892c75cc30fda",
+                  "checksum": "5b156bbd04adfaad2184b4d1e8324b21b546b40fb46e7105fa39f5ad2f34ddf3",
                   "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -537,7 +537,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "d8d7ecb0667a9b86b7ce1994731f9c9d313b46f04de59f724259a6fda685617a",
+                  "checksum": "7a70083a73719a3c7846533923d5c4e955405c2b4ba1c1abd95ed21ae8b52775",
                   "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -549,7 +549,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "65e6255c6f95b6dcf87f13c21994bc80205b4bd7c7d9a3fe1f8f2a18daec576d",
+                  "checksum": "0ae4931d0ea779ecb237c1fc9f4a27271b0054b1efabc783863478913fe6caa6",
                   "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }

--- a/contracts/sw.stack/python/contract.json
+++ b/contracts/sw.stack/python/contract.json
@@ -4,18 +4,18 @@
   "name": "Python v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "3.9.1",
-    "versionList": "`3.9.1 (latest)`, `3.8.6`, `2.7.18`, `3.7.9`, `3.6.12`, `3.5.10`",
+    "latest": "3.9.4",
+    "versionList": "`3.9.4 (latest)`, `3.8.9`, `2.7.18`, `3.7.9`, `3.6.12`, `3.5.10`",
     "introduction": "Python is an interpreted, interactive, object-oriented, open-source programming language. It incorporates modules, exceptions, dynamic typing, very high level dynamic data types, and classes. Python combines remarkable power with very clear syntax. It has interfaces to many system calls and libraries, as well as to various window systems, and is extensible in C or C++. It is also usable as an extension language for applications that need a programmable interface. Finally, Python is portable: it runs on many Unix variants, on the Mac, and on Windows 2000 and later.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/python/logo.png"
 
   },
   "assets": {
     "pip": {
-      "version": "20.3.1"
+      "version": "21.0.1"
     },
     "setuptools": {
-      "version": "51.0.0"
+      "version": "56.0.0"
     },
     "dbus": {
       "version": "1.2.8"
@@ -38,7 +38,7 @@
   ],
   "variants": [
     {
-      "version": "3.9.1",
+      "version": "3.9.4",
       "assets" : {
         "pip": {
           "command": "pip3"
@@ -71,7 +71,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "11ec5a53ceaf4a713604c888240b76ddd296e9d43ed3dfb1455160a0fd6a3380",
+                      "checksum": "2004a91f167c0fb2798555f7b2d5886b820686f589b71abe0c9a19b6334e78cc",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -98,7 +98,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "4ffe192654e4caca3464a62afbaf3ef60a2bd16b4bd7a2302e649f817e9f9188",
+                      "checksum": "001182f2fa74855d8254b5a7c6b18014e9f55767540162013c4d1baf25529555",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-amd64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -125,7 +125,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "49a7875d82810651516a8ae1adeed60aa018e36eed378344b271691374105a2a",
+                      "checksum": "f0afca04ecf89fcea4fdf52bd8c3e067181cca44032e7dae15b4cc8148d1c107",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-i386-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -152,7 +152,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "6df986081a736672ebcce32ac3109bd22330933334b87e7edcca64e5df7f1b1d",
+                      "checksum": "9c0e613b98c1adab757b0443f27a698f1e00cedf1b9e2e4dce05dff7d7ec52cb",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-aarch64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -179,7 +179,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "04ec40fea96bf6e8e32175b09961efaa18979fed53cb34b9f3b57b3f6a2c9df7",
+                      "checksum": "ed043a94289b6553f5dde55c8b8b36a67b811c510cf56909621ea165c1f5f554",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv7hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -211,7 +211,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "dcb1ae92732e151f970b8ebe52351c0edec2e8cda7611a4a4f78ec7ab390deaf",
+                  "checksum": "2fadc736844c6201178265262e32e801504a094d3b7464d33addbfe1fa3eb43d",
                   "name": "Python-$PYTHON_VERSION.linux-armv6hf-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -223,7 +223,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "14d708685cc8d0cfe988048490bf33abd2e4422683bccfbbdee0081278ca7948",
+                  "checksum": "fe3cb03bf50d2128ff7c98e16308c5c2c4363983c87e26e0ffe4b280bf78e070",
                   "name": "Python-$PYTHON_VERSION.linux-armv7hf-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -235,7 +235,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "0eade61b25e2eaeec4ce48426bc4c9f0139c73621d4d904d6ab740565f066062",
+                  "checksum": "3cfb071eb95dcc80c29339ae8c534cd5072ab687d2c1c36d7a5a432bf35c9039",
                   "name": "Python-$PYTHON_VERSION.linux-amd64-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -247,7 +247,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "833cd79bb2ec9c2a587ce8e9119d96d2f727713911570e410a4b0b758df6017f",
+                  "checksum": "6cb5376d0eb62e61085febdbeff72eaa8d80b3b535634144c364ba4be6052b17",
                   "name": "Python-$PYTHON_VERSION.linux-aarch64-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -259,7 +259,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3238ce8ff5371184007606b2bb1b97ced4c9c3fda3f9e1e4689bf79a3224b1a6",
+                  "checksum": "26335842fa94a0b64f74fc2f904bad52caf92eff7bd303d7646cba59c7ccf3e2",
                   "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -271,7 +271,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3238ce8ff5371184007606b2bb1b97ced4c9c3fda3f9e1e4689bf79a3224b1a6",
+                  "checksum": "26335842fa94a0b64f74fc2f904bad52caf92eff7bd303d7646cba59c7ccf3e2",
                   "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -285,7 +285,7 @@
       ]
     },
     {
-      "version": "3.8.6",
+      "version": "3.8.9",
       "assets" : {
         "pip": {
           "command": "pip3"
@@ -318,7 +318,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "c10d241152210af2a049a0e4b3ef7a8a35d45fcacf215cb9e5f36c9b50425313",
+                      "checksum": "5679c51f0a4250daa643dacfae5fe907bc8ee929ee2c46fcf3f8be7a655b70d0",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -345,7 +345,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "4c961ab722eb2f7e53a731c4f448525f6a2da6ab9907ce8c20006035039a9638",
+                      "checksum": "57f5474bdcb0d87be365d5e1094eae095b85a003accae2b8968b336e0e5e0ca6",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-amd64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -372,7 +372,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "c0e1d079e1e7221db3a6c1f4fdc5498e00ef72d9f135374de69e4840ee538735",
+                      "checksum": "064437fe9778bd05297831978e58737279af62870fa0ed07ab948794cf0a28a0",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-i386-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -399,7 +399,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "e1c61b20b9e3c35cc6fe765b4d49426ebfef188580592da1bdcd9ed40564e612",
+                      "checksum": "a4807442be7d69905b637bc8a4866b10ac2b5d74c5c914974ad5883dd7d94dba",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-aarch64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -426,7 +426,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "6af752b82cafd6ff54beab3a55ef091de817da9aadf802c3a23e87ed9a6abe30",
+                      "checksum": "075f5b718b96ff426b67a84f6b308a55533bd00f560ddb09756280c5e11f1eb3",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv7hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -458,7 +458,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f08a3f7515805755559d283e324efb902f83074366755b08e6e4da8b75f29ef9",
+                  "checksum": "e4c05e185162c16a1a07e493e825e9db2c80bfa96816381191b249130024346b",
                   "name": "Python-$PYTHON_VERSION.linux-armv6hf-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -470,7 +470,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "e4b03733bf3a6d2b44bcae7e1b19a05b8dd1568f88b5d13ffd27fb8fedf971a4",
+                  "checksum": "c5b7c118af6ad28d1b978513451b47e5acca51e3fc469dfc95ccf0ee9036bd82",
                   "name": "Python-$PYTHON_VERSION.linux-armv7hf-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -482,7 +482,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "faf51f82382686940f30896e5914e537166291584d1b572cdc94d4b3357babcd",
+                  "checksum": "aeffa910f8ea24fea33d4fc654d7d9aea05af625bd05ac4b9e31efc8e6769274",
                   "name": "Python-$PYTHON_VERSION.linux-amd64-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -494,7 +494,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "cfd006ced85273d8002a17b2950af3f3062c7c3b4ad37d0e0ab4d5f346c6cd13",
+                  "checksum": "8a565846e715aa422ea060155704ed2ed5b06f685e6847630d2c7e7b28b0ffc8",
                   "name": "Python-$PYTHON_VERSION.linux-aarch64-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -506,7 +506,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "48b7a9dd854690cb00bca21c8872292a26579247140c5f033fc74c5b84cf3bbb",
+                  "checksum": "28c2a14c98e4a088d6e140ec7685b12470e7b057aee56067ad6a5965c1f3b56d",
                   "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -518,7 +518,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "48b7a9dd854690cb00bca21c8872292a26579247140c5f033fc74c5b84cf3bbb",
+                  "checksum": "28c2a14c98e4a088d6e140ec7685b12470e7b057aee56067ad6a5965c1f3b56d",
                   "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }


### PR DESCRIPTION
This PR  has the following changes:
- Add node v15.14.0 v14.16.1 v12.22.1 and v10.24.1.
- Add Python v3.9.4 and v3.8.9.
- Add Go v1.16.3 and v1.15.11.