### PR TITLE
Add instruction partials to etcher supported device types

### DIFF
--- a/contracts/hw.device-type/aio-3288c/contract.json
+++ b/contracts/hw.device-type/aio-3288c/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/astro-tx2/contract.json
+++ b/contracts/hw.device-type/astro-tx2/contract.json
@@ -24,6 +24,14 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": ["Connect power to the {{name}}"],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/asus-tinker-board-s/contract.json
+++ b/contracts/hw.device-type/asus-tinker-board-s/contract.json
@@ -25,6 +25,20 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Make sure that the jumper between the 5V power supply and the HDMI connect is in the MASKROM mode as illustrated on the <a href=\"https://tinkerboarding.co.uk/wiki/index.php/Setup\">Tinker Board Wiki</a>",
+      "Connect power to the {{name}}"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": [
+      "Make sure that the jumper between the 5V power supply and the HDMI connect is in the parking (no function) mode as illustrated on the <a href=\"https://tinkerboarding.co.uk/wiki/index.php/Setup\">Tinker Board Wiki</a>",
+      "Remove and re-connect power to the {{name}}"
+    ]
   }
 }

--- a/contracts/hw.device-type/asus-tinker-board/contract.json
+++ b/contracts/hw.device-type/asus-tinker-board/contract.json
@@ -25,6 +25,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/asus-tinker-edge-t/contract.json
+++ b/contracts/hw.device-type/asus-tinker-edge-t/contract.json
@@ -24,6 +24,20 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Set the BOOT_SELECT switch to the SD-CARD position",
+      "Connect power to the {{name}}"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": [
+      "Set the BOOT_SELECT switch to the eMMC position",
+      "Remove and re-connect power to the {{name}}"
+    ]
   }
 }

--- a/contracts/hw.device-type/bananapi-m1-plus/contract.json
+++ b/contracts/hw.device-type/bananapi-m1-plus/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/beagleboard-xm/contract.json
+++ b/contracts/hw.device-type/beagleboard-xm/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/beaglebone-black/contract.json
+++ b/contracts/hw.device-type/beaglebone-black/contract.json
@@ -24,6 +24,14 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": ["Power up the {{name}} while holding down the small button near the SD slot. You need to keep it pressed until the blue LEDs start flashing wildly."],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/beaglebone-green-gateway/contract.json
+++ b/contracts/hw.device-type/beaglebone-green-gateway/contract.json
@@ -24,6 +24,14 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": ["Power up the {{name}} while holding down the small button near the SD slot. You need to keep it pressed until the blue LEDs start flashing wildly."],
+    "flashIndicator": ["5 seconds after the LEDs have stopped flashing wildly"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/beaglebone-green-wifi/contract.json
+++ b/contracts/hw.device-type/beaglebone-green-wifi/contract.json
@@ -24,6 +24,14 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": ["Power up the {{name}} while holding down the small button near the SD slot. You need to keep it pressed until the blue LEDs start flashing wildly."],
+    "flashIndicator": ["5 seconds after the LEDs have stopped flashing wildly"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/beaglebone-green/contract.json
+++ b/contracts/hw.device-type/beaglebone-green/contract.json
@@ -24,6 +24,14 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": ["Power up the {{name}} while holding down the small button near the SD slot. You need to keep it pressed until the blue LEDs start flashing wildly."],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/beaglebone-pocket/contract.json
+++ b/contracts/hw.device-type/beaglebone-pocket/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/blackboard-tx2/contract.json
+++ b/contracts/hw.device-type/blackboard-tx2/contract.json
@@ -24,6 +24,17 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Connect power to the {{name}}",
+      "Press and hold the POWER push button for 1 second"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/ccimx8x-sbc-pro/contract.json
+++ b/contracts/hw.device-type/ccimx8x-sbc-pro/contract.json
@@ -24,6 +24,21 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Make sure your {{name}} contains a system-on-module with a 2GB i.MX8X quad B0 system-on-chip. Different module variants are not supported and will not boot.",
+      "Configure the boot microswitches (S2) for SD boot (SW1 OFF and SW2 ON)",
+      "Connect power to the {{name}}"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": [
+      "Configure the boot microswitches (S2) for internal (eMMC) boot (SW1 OFF and SW2 OFF)",
+      "Remove and re-connect power to the {{name}}"
+    ]
   }
 }

--- a/contracts/hw.device-type/cl-som-imx8/contract.json
+++ b/contracts/hw.device-type/cl-som-imx8/contract.json
@@ -24,6 +24,18 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Connect power to the {{name}}",
+      "Press and hold SW5 followed by SW6",
+      "Release SW5 followed by SW6"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/coral-dev/contract.json
+++ b/contracts/hw.device-type/coral-dev/contract.json
@@ -24,6 +24,20 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Set the BOOT_SELECT switch to the SD-CARD position",
+      "Connect power to the {{name}}"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": [
+      "Set the BOOT_SELECT switch to the SD-CARD position",
+      "Remove and re-connect power to the {{name}}"
+    ]
   }
 }

--- a/contracts/hw.device-type/etcher-pro/contract.json
+++ b/contracts/hw.device-type/etcher-pro/contract.json
@@ -23,6 +23,20 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Set the DSW1 switch to the ON position",
+      "Connect power to the {{name}}"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": [
+      "Set the DSW1 switch to the OFF position",
+      "Remove and re-connect power to the {{name}}"
+    ]
   }
 }

--- a/contracts/hw.device-type/fincm3/contract.json
+++ b/contracts/hw.device-type/fincm3/contract.json
@@ -24,6 +24,17 @@
     "media": {
       "installation": "dfu"
     },
+    "installation": {
+      "method": "internalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "connectDevice": [
+      "While not having the {{name}} board powered, connect your system to the board's DBG/PRG port via a micro-USB cable.",
+      "<em>Note: for the {{name}} v1.1, only power the board from the PRG port for flashing. For the {{name}} v1.0, power on the board by attaching power to either the Barrel or the Phoenix connector.</em>"
+    ],
+    "disconnectDevice": ["Power off the {{name}} by detaching the power if connected and unplug the DGB micro-USB cable."],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/firefly-rk3288/contract.json
+++ b/contracts/hw.device-type/firefly-rk3288/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/imx6ul-var-dart/contract.json
+++ b/contracts/hw.device-type/imx6ul-var-dart/contract.json
@@ -24,6 +24,18 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Connect power to the {{name}}",
+      "Press and hold the SW2 button followed by the SW1 button",
+      "Release the SW1 button followed by the SW2 button"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/imx7-var-som/contract.json
+++ b/contracts/hw.device-type/imx7-var-som/contract.json
@@ -24,6 +24,20 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Set the SW1 BOOT-SELECT switch to SD-CARD",
+      "Connect power to the {{name}}"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": [
+      "Set the SW1 BOOT-SELECT switch to eMMC",
+      "Remove and re-connect power to the {{name}}"
+    ]
   }
 }

--- a/contracts/hw.device-type/imx8m-var-dart/contract.json
+++ b/contracts/hw.device-type/imx8m-var-dart/contract.json
@@ -24,6 +24,20 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Set the SW7 BOOT-SELECT switch to SD-CARD",
+      "Connect power to the {{name}}"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": [
+      "Set the SW7 BOOT-SELECT switch to eMMC",
+      "Remove and re-connect power to the {{name}}"
+    ]
   }
 }

--- a/contracts/hw.device-type/imx8mm-var-dart/contract.json
+++ b/contracts/hw.device-type/imx8mm-var-dart/contract.json
@@ -24,6 +24,20 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Set the SW7 BOOT-SELECT switch to EXT",
+      "Connect power to the {{name}}"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": [
+      "Set the SW7 BOOT-SELECT switch to INT",
+      "Remove and re-connect power to the {{name}}"
+    ]
   }
 }

--- a/contracts/hw.device-type/intel-nuc/contract.json
+++ b/contracts/hw.device-type/intel-nuc/contract.json
@@ -24,6 +24,19 @@
     "media": {
       "installation": "usbkey"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Ensure there are no other USB keys are inserted",
+      "Power on the {{name}} with a keyboard connected",
+      "Press the F10 key whie BIOS is loading to enter the boot menu",
+      "Select the USB key from the boot menu"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Power up the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/iot-gate-imx8/contract.json
+++ b/contracts/hw.device-type/iot-gate-imx8/contract.json
@@ -24,6 +24,14 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": ["Connect power to the {{name}}"],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/jetson-nano-2gb-devkit/contract.json
+++ b/contracts/hw.device-type/jetson-nano-2gb-devkit/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/jetson-nano/contract.json
+++ b/contracts/hw.device-type/jetson-nano/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/jetson-tx1/contract.json
+++ b/contracts/hw.device-type/jetson-tx1/contract.json
@@ -24,6 +24,16 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Connect power to the {{name}} and press and hold the POWER push button for 1 second"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/jetson-tx2/contract.json
+++ b/contracts/hw.device-type/jetson-tx2/contract.json
@@ -24,6 +24,16 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Connect power to the {{name}} and press and hold the POWER push button for 1 second"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/jetson-xavier-nx-devkit-seeed-2mic-hat/contract.json
+++ b/contracts/hw.device-type/jetson-xavier-nx-devkit-seeed-2mic-hat/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/jetson-xavier-nx-devkit/contract.json
+++ b/contracts/hw.device-type/jetson-xavier-nx-devkit/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/jn30b-nano/contract.json
+++ b/contracts/hw.device-type/jn30b-nano/contract.json
@@ -22,8 +22,14 @@
       "internal": true
     },
     "media": {
-      "installation": "dfu"
+      "installation": "sdcard"
+    },
+    "installation": {
+      "method": "externalBoot"
     },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/n510-tx2/contract.json
+++ b/contracts/hw.device-type/n510-tx2/contract.json
@@ -24,6 +24,14 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": ["Connect power to the {{name}}"],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/nanopc-t4/contract.json
+++ b/contracts/hw.device-type/nanopc-t4/contract.json
@@ -24,6 +24,14 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": ["Connect power to the {{name}}"],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/nanopi-neo-air/contract.json
+++ b/contracts/hw.device-type/nanopi-neo-air/contract.json
@@ -24,6 +24,14 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": ["Connect power to the {{name}}"],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/nitrogen8mm/contract.json
+++ b/contracts/hw.device-type/nitrogen8mm/contract.json
@@ -24,6 +24,13 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": ["Connect power to the {{name}}"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/npe-x500-m3/contract.json
+++ b/contracts/hw.device-type/npe-x500-m3/contract.json
@@ -23,6 +23,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/odroid-c1/contract.json
+++ b/contracts/hw.device-type/odroid-c1/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/odroid-xu4/contract.json
+++ b/contracts/hw.device-type/odroid-xu4/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/orange-pi-one/contract.json
+++ b/contracts/hw.device-type/orange-pi-one/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/orange-pi-zero/contract.json
+++ b/contracts/hw.device-type/orange-pi-zero/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/orangepi-plus2/contract.json
+++ b/contracts/hw.device-type/orangepi-plus2/contract.json
@@ -24,6 +24,14 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": ["Connect power to the {{name}}"],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/orbitty-tx2/contract.json
+++ b/contracts/hw.device-type/orbitty-tx2/contract.json
@@ -24,6 +24,14 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": ["Connect power to the {{name}}"],
+    "flashIndicator": ["the SYS LED is turned off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/raspberry-pi/contract.json
+++ b/contracts/hw.device-type/raspberry-pi/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/raspberry-pi2/contract.json
+++ b/contracts/hw.device-type/raspberry-pi2/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/raspberrypi3-64/contract.json
+++ b/contracts/hw.device-type/raspberrypi3-64/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/raspberrypi3/contract.json
+++ b/contracts/hw.device-type/raspberrypi3/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/raspberrypi4-64/contract.json
+++ b/contracts/hw.device-type/raspberrypi4-64/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/raspberrypi400-64/contract.json
+++ b/contracts/hw.device-type/raspberrypi400-64/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/revpi-connect/contract.json
+++ b/contracts/hw.device-type/revpi-connect/contract.json
@@ -24,6 +24,17 @@
     "media": {
       "installation": "dfu"
     },
+    "installation": {
+      "method": "internalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "connectDevice": [
+      "While not having the {{name}} board powered, connect your system to the board's USB port via a micro-USB cable",
+      "Power on the {{name}}"
+    ],
+    "disconnectDevice": ["Power off the {{name}} and unplug the micro-USB cable"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/revpi-core-3/contract.json
+++ b/contracts/hw.device-type/revpi-core-3/contract.json
@@ -24,6 +24,17 @@
     "media": {
       "installation": "dfu"
     },
+    "installation": {
+      "method": "internalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "connectDevice": [
+      "While not having the {{name}} board powered, connect your system to the board's USB port via a micro-USB cable",
+      "Power on the {{name}}"
+    ],
+    "disconnectDevice": ["Power off the {{name}} and unplug the micro-USB cable"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/smarc-px30/contract.json
+++ b/contracts/hw.device-type/smarc-px30/contract.json
@@ -24,6 +24,12 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalBoot"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/spacely-tx2/contract.json
+++ b/contracts/hw.device-type/spacely-tx2/contract.json
@@ -24,6 +24,14 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": ["Connect power to the {{name}}"],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Remove and re-connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/surface-go/contract.json
+++ b/contracts/hw.device-type/surface-go/contract.json
@@ -24,6 +24,17 @@
     "media": {
       "installation": "usbkey"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Press and hold the Volume Down button and press the Power button",
+      "Release the power button but keep pressing the Volume Down button until the windows logo disappears"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Press the Power button on the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/surface-pro-6/contract.json
+++ b/contracts/hw.device-type/surface-pro-6/contract.json
@@ -24,6 +24,17 @@
     "media": {
       "installation": "usbkey"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Press and hold the Volume Down button and press the Power button",
+      "Release the power button but keep pressing the Volume Down button until the windows logo disappears"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Press the Power button on the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/ts4900/contract.json
+++ b/contracts/hw.device-type/ts4900/contract.json
@@ -24,6 +24,20 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Enable the SD boot jumper on the {{name}}",
+      "Connect power to the {{name}}"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": [
+      "Disable the SD boot jumper on the {{name}}",
+      "Remove and re-connect power to the {{name}}"
+    ]
   }
 }

--- a/contracts/hw.device-type/up-board/contract.json
+++ b/contracts/hw.device-type/up-board/contract.json
@@ -25,6 +25,18 @@
     "media": {
       "installation": "usbkey"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Power on the {{name}} with a keyboard connected",
+      "Press the F7 key whie BIOS is loading to enter the boot menu",
+      "Select the \"UEFI:\" option from the boot menu"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": ["Power up the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/var-som-mx6/contract.json
+++ b/contracts/hw.device-type/var-som-mx6/contract.json
@@ -24,6 +24,20 @@
     "media": {
       "installation": "sdcard"
     },
+    "installation": {
+      "method": "externalFlash"
+    },
     "is_private": false
+  },
+  "partials": {
+    "bootDeviceExternal": [
+      "Set the BOOT-SELECT switch to MMC",
+      "Connect power to the {{name}}"
+    ],
+    "flashIndicator": ["all LEDs are off"],
+    "bootDevice": [
+      "Set the BOOT-SELECT switch to NAND",
+      "Remove and re-connect power to the {{name}}"
+    ]
   }
 }


### PR DESCRIPTION
This PR replaces the deprecated instruction generation approach that was being implemented in #173.

So far this adds instructions for all device types that support Etcher based installations either directly flashing the board from Etcher, externally booting from media, or flashing internal storage from an external media source. Still need to add support for devices that use other methods such as the Jetson flashing tool

Change-type: minor
Signed-off-by: Micah Halter <micah@balena.io>