### PR TITLE
Various base images updates

### DIFF
--- a/contracts/sw.os+arch.sw/alpine/build.tpl
+++ b/contracts/sw.os+arch.sw/alpine/build.tpl
@@ -16,7 +16,7 @@ RUN apk add --update \
 		glib-dev \
 		jpeg-dev \
 		imagemagick-dev \
-		ncurses5-libs \
+		ncurses-libs \
 		libpq \
 		readline-dev \
 		sqlite-dev \

--- a/contracts/sw.os/alpine/contract.json
+++ b/contracts/sw.os/alpine/contract.json
@@ -5,7 +5,7 @@
   "data": { 
     "libc": "musl-libc",
     "latest": "3.13",
-    "versionList": "`3.13 (latest)`, `3.11`, `3.10`, `3.12`, `edge`"
+    "versionList": "`3.13 (latest)`, `3.14`, `3.11`, `3.12`, `edge`"
   },
   "name": "Alpine Linux {{this.version}}",
   "requires": [
@@ -36,10 +36,10 @@
       ],
       "variants": [
         { "version": "edge" },
+        { "version": "3.14" },
+        { "version": "3.13" },
         { "version": "3.12" },
-        { "version": "3.10" },
-        { "version": "3.11" },
-        { "version": "3.13" }
+        { "version": "3.11" }
       ]
     },
     {
@@ -53,10 +53,10 @@
       ],
       "variants": [
         { "version": "edge" },
+        { "version": "3.14" },
+        { "version": "3.13" },
         { "version": "3.12" },
-        { "version": "3.10" },
-        { "version": "3.11" },
-        { "version": "3.13" }
+        { "version": "3.11" }
       ]
     }
   ]

--- a/contracts/sw.stack+sw.os+hw.device-type/openjdk@16-jdk+debian/build.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/openjdk@16-jdk+debian/build.tpl
@@ -1,0 +1,47 @@
+# A few reasons for installing distribution-provided OpenJDK:
+#
+#  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
+#  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		bzip2 \
+		unzip \
+		xz-utils \
+		binutils \
+		fontconfig libfreetype6 \
+		ca-certificates p11-kit \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/local/openjdk-16
+ENV PATH $JAVA_HOME/bin:$PATH
+
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
+
+RUN curl -SLO "{{sw.stack.assets.bin.url}}" \
+	&& echo "{{sw.stack.assets.bin.checksum}}  {{sw.stack.assets.bin.name}}" | sha256sum -c - \
+	&& mkdir -p "$JAVA_HOME" \
+	&& tar --extract \
+		--file {{sw.stack.assets.bin.name}} \
+		--directory "$JAVA_HOME" \
+		--strip-components 1 \
+		--no-same-owner \
+	&& rm -f {{sw.stack.assets.bin.name}} \
+	&& { \
+		echo '#!/usr/bin/env bash'; \
+		echo 'set -Eeuo pipefail'; \
+		echo 'trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose=server-auth "$JAVA_HOME/lib/security/cacerts"'; \
+	} > /etc/ca-certificates/update.d/docker-openjdk \
+	&& chmod +x /etc/ca-certificates/update.d/docker-openjdk \
+	&& /etc/ca-certificates/update.d/docker-openjdk \
+	&& find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf \
+	&& ldconfig \
+	&& java -Xshare:dump \
+	&& fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \
+	&& javac --version \
+	&& java --version

--- a/contracts/sw.stack+sw.os+hw.device-type/openjdk@16-jdk+debian/run.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/openjdk@16-jdk+debian/run.tpl
@@ -1,0 +1,47 @@
+# A few reasons for installing distribution-provided OpenJDK:
+#
+#  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
+#  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		bzip2 \
+		unzip \
+		xz-utils \
+		binutils \
+		fontconfig libfreetype6 \
+		ca-certificates p11-kit \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/local/openjdk-16
+ENV PATH $JAVA_HOME/bin:$PATH
+
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
+
+RUN curl -SLO "{{sw.stack.assets.bin.url}}" \
+	&& echo "{{sw.stack.assets.bin.checksum}}  {{sw.stack.assets.bin.name}}" | sha256sum -c - \
+	&& mkdir -p "$JAVA_HOME" \
+	&& tar --extract \
+		--file {{sw.stack.assets.bin.name}} \
+		--directory "$JAVA_HOME" \
+		--strip-components 1 \
+		--no-same-owner \
+	&& rm -f {{sw.stack.assets.bin.name}} \
+	&& { \
+		echo '#!/usr/bin/env bash'; \
+		echo 'set -Eeuo pipefail'; \
+		echo 'trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose=server-auth "$JAVA_HOME/lib/security/cacerts"'; \
+	} > /etc/ca-certificates/update.d/docker-openjdk \
+	&& chmod +x /etc/ca-certificates/update.d/docker-openjdk \
+	&& /etc/ca-certificates/update.d/docker-openjdk \
+	&& find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf \
+	&& ldconfig \
+	&& java -Xshare:dump \
+	&& fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java \
+	&& javac --version \
+	&& java --version

--- a/contracts/sw.stack/golang/contract.json
+++ b/contracts/sw.stack/golang/contract.json
@@ -4,8 +4,8 @@
   "name": "Go v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "1.16.3",
-    "versionList": "`1.16.3 (latest)`, `1.15.11`, `1.14.14`",
+    "latest": "1.16.5",
+    "versionList": "`1.16.5 (latest)`, `1.15.13`",
     "introduction": "Go (a.k.a., Golang) is a programming language first developed at Google. It is a statically-typed language with syntax loosely derived from C, but with additional features such as garbage collection, type safety, some dynamic-typing capabilities, additional built-in types (e.g., variable-length arrays and key-value maps), and a large standard library.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/golang/logo.png"
   },
@@ -28,7 +28,7 @@
   },
   "variants": [
     {
-      "version": "1.16.3",
+      "version": "1.16.5",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -39,7 +39,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "d235bfc0aeed43fc46ba644cef94e280fd08a65ec5881b9c6a78189c35828b09",
+                  "checksum": "0066014ce8e829bf8c9196dff7e386001589dcf8e2bd8b63337da38b5793e261",
                   "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                   
@@ -52,7 +52,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "10d1c63534be387026f37a3ac3ed00c7258dfbc3ed40255956bc736cf8b3bf3b",
+                  "checksum": "4ecc1e644b3a052ae77135d644968edf32de990ecd26611b17edb00f184bc7d8",
                   "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -64,7 +64,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f01da465a37f3360ce0126ef7847de5d50bb16eaf4578361dca653707c0068fa",
+                  "checksum": "70e463519052665abbe9bb3100aa29cb80f7a121ed8747d5a8982fece7a417a5",
                   "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -76,7 +76,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "d4b5a5116b9d29e1b1bf4547edd03ee8c913a6a511fb05395cdc23a26ab57ff1",
+                  "checksum": "bb3cb64da7c75b13daf9358f3e2d83a37f27a3b73bd1199424fc6d2f482b2e38",
                   "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -88,7 +88,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "82d3d01d1f341b3afb21b1c650fe7edc6b1b4757bfef78a46a39faa4ee411b8d",
+                  "checksum": "baa1d097cd9b2ce89a2836a6c1cc6bc7cece6ee197e9114f966e9621a25dccff",
                   "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -114,7 +114,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "0dae30385e3564a557dac7f12a63eedc73543e6da0f6017990e214ce8cc8797c",
+                  "checksum": "93cacacfbe87e3106b5bf5821de106f0f0a43c8bd1029826d44445c15df795a5",
                   "name": "go$GO_VERSION.linux-armv6l.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -126,7 +126,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "0cfbfa848a1ab81e2aa2dd257c2b3572c3637d32562b1eaa6aeadb2909911606",
+                  "checksum": "744ea3841cd887892173db451b33d7e4af70e7b70d322501a44bfa61268cfc07",
                   "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -138,7 +138,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2",
+                  "checksum": "b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061",
                   "name": "go$GO_VERSION.linux-amd64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -150,7 +150,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f4e96bbcd5d2d1942f5b55d9e4ab19564da4fad192012f6d7b0b9b055ba4208f",
+                  "checksum": "d5446b46ef6f36fdffa852f73dfbbe78c1ddf010b99fa4964944b9ae8b4d6799",
                   "name": "go$GO_VERSION.linux-arm64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -162,7 +162,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "48b2d1481db756c88c18b1f064dbfc3e265ce4a775a23177ca17e25d13a24c5d",
+                  "checksum": "a37c6b71d0b673fe8dfeb2a8b3de78824f05d680ad32b7ac6b58c573fa6695de",
                   "name": "go$GO_VERSION.linux-386.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -176,7 +176,7 @@
       ]
     },
     {
-      "version": "1.15.11",
+      "version": "1.15.13",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -187,7 +187,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "fa4101336d9fa0e0908d898c45db80f7cf782112adc77d8e2d85536c21112bc4",
+                  "checksum": "6a4451492fb1563322812a1d26472e809c06292988d6be169fb8235bbd95868e",
                   "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -199,7 +199,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "34461bd1eebacd268bca32a27581a0b5dd177000719228641864c421626ca6e6",
+                  "checksum": "96c092b72ce49453ffccbdf9b350cb24bf493a21d87af00f9161580143fbdc4d",
                   "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -211,7 +211,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f4b63996b23199c4f38b1cf412ea9c42009c4b36fab9469134616e9f9c402836",
+                  "checksum": "643d11596d12ecfdbd42bf63ff89074babed8bc9c6d185698f6f676aa81256be",
                   "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -223,7 +223,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f944eac62687471e30c4183d7b91cd33cf55a8a84d49176a075e01bfc19b4eb0",
+                  "checksum": "a0cf59cf8b563a4489207fba6e95e3060250849ae3d24f8458de1399e3a8ba29",
                   "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -235,7 +235,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "e460a686d088a08244e6e360ce70f957854c74d7f82d8fce91a1bf3b43c54436",
+                  "checksum": "dfba82907502228b543619af3c0ad5071ddb8c5bcc5ea1e3d6c1bf9b33a1e84b",
                   "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -261,7 +261,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "dba11ed018fc7b5774ca996c4bdb847f8f9535cdc4932eb09a43c390813af4c9",
+                  "checksum": "00ff453f102c67ff6b790ba0cb10cecf73c8e8bbd9d913e5978ac8cc6323132f",
                   "name": "go$GO_VERSION.linux-armv6l.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -273,7 +273,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f5253eb04ed6b92e49cb0cbc57a80b4777ce27c6590e05a5c91095870e8632a0",
+                  "checksum": "c1a2e3e6bdbf0fb439a4562d3be9863698c9d2476394535761656d9d13cc61bd",
                   "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -285,7 +285,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec",
+                  "checksum": "3d3beec5fc66659018e09f40abb7274b10794229ba7c1e8bdb7d8ca77b656a13",
                   "name": "go$GO_VERSION.linux-amd64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -297,7 +297,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "bfc8f07945296e97c6d28c7999d86b5cab51c7a87eb2b22ca6781c41a6bb6f2d",
+                  "checksum": "f3989dca4dea5fbadfec253d7c24e4111773b203e677abb1f01e768a99cc14e6",
                   "name": "go$GO_VERSION.linux-arm64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -309,7 +309,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "2de51fc6873d8b688d7451cfc87443ef49404af98bbab9c8a36fb6c4bc95e4de",
+                  "checksum": "8df80ccbbd57b108ec43066925bf02aac47bc9e0236894dbd019f26944d27399",
                   "name": "go$GO_VERSION.linux-386.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }

--- a/contracts/sw.stack/node/contract.json
+++ b/contracts/sw.stack/node/contract.json
@@ -307,8 +307,7 @@
           "data": { "libc": "musl-libc" },
           "requires": [
             { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
-            { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-            { "type": "sw.os", "slug": "alpine" , "version": "3.10" }
+            { "type": "sw.os", "slug": "alpine" , "version": "3.11" }
           ],
           "variants": [
             {
@@ -432,8 +431,7 @@
           "data": { "libc": "musl-libc" },
           "requires": [
             { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
-            { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-            { "type": "sw.os", "slug": "alpine" , "version": "3.10" }
+            { "type": "sw.os", "slug": "alpine" , "version": "3.11" }
           ],
           "variants": [
             {

--- a/contracts/sw.stack/node/contract.json
+++ b/contracts/sw.stack/node/contract.json
@@ -4,8 +4,8 @@
   "name": "Node.js v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "16.1.0",
-    "versionList": "`16.1.0 (latest)`, `14.16.1`, `12.21.1`, `10.24.1`",
+    "latest": "16.4.0",
+    "versionList": "`16.4.0 (latest)`, `14.16.1`, `12.21.1`, `10.24.1`",
     "introduction": "Node.js is a software platform for scalable server-side and networking applications. Node.js applications are written in JavaScript and can be run within the Node.js runtime on Mac OS X, Windows, and Linux without changes.\n\nNode.js applications are designed to maximize throughput and efficiency, using non-blocking I/O and asynchronous events. Node.js applications run single-threaded, although Node.js uses multiple threads for file and network events. Node.js is commonly used for real-time applications due to its asynchronous nature.\n\nNode.js internally uses the Google V8 JavaScript engine to execute code; a large percentage of the basic modules are written in JavaScript. Node.js contains a built-in, asynchronous I/O library for file, socket, and HTTP communication. The HTTP and socket support allows Node.js to act as a web server without additional software such as Apache.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/node/logo.png"
   },
@@ -31,7 +31,7 @@
   ],
   "variants": [
     {
-      "version": "16.1.0",
+      "version": "16.4.0",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -42,7 +42,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "352ca71c7f2c78b93f617149d373d6b8c6dcfcd377465830e9c8414b556cf90e",
+                  "checksum": "c7e532bdf7dee91d455c480112450fa223a5429c7261aec8f26a6e46f9138d1d",
                   "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -54,7 +54,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "d7cd5dd6e32f78983d9cfeda32829b6fe186be80a6d37eecc39ebea1f60853d2",
+                  "checksum": "59ed1f7559bdf40445c9107f295aebd3dcffafaa8d4e7e6c56dc8d08dc7adf8a",
                   "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -66,7 +66,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "d7d83a3b32a62983fa2691de660c8778964eacedc7e852267220fc7667508708",
+                  "checksum": "9c30a7866f2f0d38a650ef73b4595e86d43b8919367aef40ff788cf78a2d2b22",
                   "name": "node-v$NODE_VERSION-linux-aarch64-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -78,7 +78,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "659506f847d7058ce5b68c5e4be2130fe9418f908dbdfc0617275f2b76617d9e",
+                  "checksum": "dcd3d44cfae58d4632212d2caeb7d4d4dd388815f97356f58b9442841982cda6",
                   "name": "node-v$NODE_VERSION-linux-armv6hf-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -90,7 +90,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "29a2e268010a6e8a89bc75f7a4f1d9269eb8046bd3a80c0c8f2935f8af647ea5",
+                  "checksum": "c2f16e137b85fcb844244aa2fd92711cff4d6766b4fb74be61f460c7b3d4b1c0",
                   "name": "node-v$NODE_VERSION-linux-armv7hf-alpine.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -116,7 +116,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "cd4a9900183fc9d61f2033c39e5f78b4ab3f0ea7a38623cafa7d78a78dea14cc",
+                  "checksum": "0a40f6d679f8eccab2b9c43a385172fa0b0584246eef2c41c986fdf572206fa8",
                   "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -128,7 +128,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "50dadc0c130ff7d079d0fb4a86e40756c76edb3cd3b42b8cf2a57497116695fa",
+                  "checksum": "6fb7bc9aece48f2d94941c586ed5d541ac29c8981bc09585fcabe9e4b87d57fa",
                   "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -140,7 +140,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a96f07133c6a45b1287e03d4fab466436fcc6589cd9a84f6081facad02bae6d8",
+                  "checksum": "8500c9b61717eeeb6f62ed88723dc4896b1bd0a38d8a0f8f8bfcd99e4879e921",
                   "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -152,7 +152,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "9812f4a13755ff9593926e6c0f48087c76122bfe2533b5b57ff4fc70970175e9",
+                  "checksum": "02b609220f41ba5fb53692b57e53fff154cb64020859d8adb3929e440e982970",
                   "name": "node-v$NODE_VERSION-linux-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }

--- a/contracts/sw.stack/openjdk/contract.json
+++ b/contracts/sw.stack/openjdk/contract.json
@@ -111,6 +111,47 @@
           ]
         }
       ]
+    },
+    {
+      "version": "16-jdk",
+      "variants": [
+        {
+          "requires": [
+            { "type": "arch.sw", "slug": "amd64" },
+            {
+              "or": [
+                { "type": "sw.os", "slug": "debian", "version": "buster" },
+                { "type": "sw.os", "slug": "debian", "version": "bullseye" }
+              ]
+            }
+          ],
+          "assets": {
+            "bin": {
+              "checksum": "b1198ffffb7d26a3fdedc0fa599f60a0d12aa60da1714b56c1defbce95d8b235",
+              "name": "openjdk-16.0.1_linux-x64_bin.tar.gz",
+              "url": "https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz"
+            }
+          }
+        },
+        {
+          "requires": [
+            { "type": "arch.sw", "slug": "aarch64" },
+            {
+              "or": [
+                { "type": "sw.os", "slug": "debian", "version": "buster" },
+                { "type": "sw.os", "slug": "debian", "version": "bullseye" }
+              ]
+            }
+          ],
+          "assets": {
+            "bin": {
+              "checksum": "602b005074777df2a0b4306e20152a6446803edd87ccbab95b2f313c4d9be6ba",
+              "name": "openjdk-16.0.1_linux-aarch64_bin.tar.gz",
+              "url": "https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-aarch64_bin.tar.gz"
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/contracts/sw.stack/python/contract.json
+++ b/contracts/sw.stack/python/contract.json
@@ -18,7 +18,7 @@
       "version": "56.0.0"
     },
     "dbus": {
-      "version": "1.2.8"
+      "version": "1.2.16"
     },
     "test": {
       "main": "test-stack@python",

--- a/contracts/sw.stack/python/contract.json
+++ b/contracts/sw.stack/python/contract.json
@@ -64,7 +64,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -91,7 +91,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -118,7 +118,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -145,7 +145,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -172,7 +172,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -311,7 +311,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -338,7 +338,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -365,7 +365,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -392,7 +392,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -419,7 +419,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -558,7 +558,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -585,7 +585,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -612,7 +612,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -639,7 +639,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -666,7 +666,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -805,7 +805,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -832,7 +832,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -859,7 +859,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -886,7 +886,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -913,7 +913,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -1165,7 +1165,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -1192,7 +1192,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -1219,7 +1219,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -1246,7 +1246,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -1273,7 +1273,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -1610,7 +1610,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -1637,7 +1637,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -1664,7 +1664,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -1691,7 +1691,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }
@@ -1718,7 +1718,7 @@
                         { "type": "sw.os", "slug": "alpine" , "version": "3.13" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.12" },
                         { "type": "sw.os", "slug": "alpine" , "version": "3.11" },
-                        { "type": "sw.os", "slug": "alpine" , "version": "3.10" },
+                        { "type": "sw.os", "slug": "alpine" , "version": "3.14" },
                         { "type": "sw.os", "slug": "alpine" , "version": "edge" }
                       ]
                     }


### PR DESCRIPTION
This PR contains the following changes:
- Add golang v1.16.5 and v1.15.13.
- Update python-dbus to v1.2.16.
- Add node v16.4.0.
- Add support for Alpine Linux 3.14.
- Add openjdk-16 for amd64 and aarch64 Debian Buster.