### PR TITLE
jetsons: Update the rest of sources.list to L4T 32.5.1

### DIFF
--- a/contracts/sw.os+hw.device-type/debian+jetson-tx2/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-tx2/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit-emmc/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit-emmc/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-tx2/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-tx2/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit-emmc/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit-emmc/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.4 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall


### PR DESCRIPTION
We are currently rolling out BalenaOS images for
Jetson devices based on L4T 32.5.1, let's update
the base image sources.list files.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>