### PR TITLE
Few base images updates

### DIFF
--- a/contracts/sw.stack/dotnet/contract.json
+++ b/contracts/sw.stack/dotnet/contract.json
@@ -28,7 +28,7 @@
   "variants": [
     {
       "version": "5.0-sdk",
-      "data": { "fullVersion": "5.0.300" },
+      "data": { "fullVersion": "5.0.400" },
       "variants": [
         {
           "data": { "libc": "glibc" },
@@ -44,7 +44,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "9e507eac7d6598188766d6281ee8102c8f2b738611a4050cc7cbce7723591dce4b6e8d35588561741852f46a6f9af4fd4b715c328007a461cc5fb468d7ab0d8c",
+                  "checksum": "432802c0a37fcc005bac98f7a363ff1484f3c0721c5202c9ed7761e1ae0d8b8496fe7be09a640da55c34bceb9eb63dfe509c5397cbc7afd44cc84ad4bf9f5e16",
                   "name": "dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/{{this.assets.bin.name}}"
                 }
@@ -56,7 +56,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "724a8e6ed77d2d3b957b8e5eda82ca8c99152d8691d1779b4a637d9ff781775f983468ee46b0bc8ad0ddbfd9d537dd8decb6784f43edae72c9529a90767310d2",
+                  "checksum": "4d1a92e0885ade03de0fdb41c27cfd948ab749a2f3e686c4a9dee314888c19d76efa6f8663a7aa7eb56cf36f508638c1a1f01c845d1acb19d8662d6ae365d572",
                   "name": "dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/{{this.assets.bin.name}}"
                 }
@@ -68,7 +68,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "654e625627b35d9b8e4e5967c76485d0ff91769f5bb5429c99e0554c601426de1b26a5c37d32ab4bc227a15409c134757d5422944cf52c945b351c5927a28393",
+                  "checksum": "de0cf29ba176529c142c7538ce557b8af1ca978abe3cc6e079ed9cbc8adc41779ad7e28ed519b37e9b16f54381d94fd7842572b3629d65f5494f1ce7bb2a3810",
                   "name": "dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm64.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/{{this.assets.bin.name}}"
                 }
@@ -83,7 +83,7 @@
     },
     {
       "version": "3.1-sdk",
-      "data": { "fullVersion": "3.1.409" },
+      "data": { "fullVersion": "3.1.412" },
       "variants": [
         {
           "data": { "libc": "glibc" },
@@ -100,7 +100,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "4908a84951a93acac80c6e7d2dff88b40b90fa079bfc0a02678a70c412a45f1146a3d344c218791edef4bb972d549accadcbfcdc721be0478b07db3a3336cf6d",
+                  "checksum": "3c66abcdef095db393ecd25501ba1e13c5a78b79ce65e6bd9ddcc3a559528eab21b0a95b39acb86e5f7f8565ae7a799e6c7e6d723121132110f93eb868cf81eb",
                   "name": "dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/{{this.assets.bin.name}}"
                 }
@@ -112,7 +112,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "63d24f1039f68abc46bf40a521f19720ca74a4d89a2b99d91dfd6216b43a81d74f672f74708efa6f6320058aa49bf13995638e3b8057efcfc84a2877527d56b6",
+                  "checksum": "1ed0c1ab48723cef834906a55fb1889b29dd810cd2bc66cbd345a0baf8a2796045b5b7f4beef3c48bd56bef3ffed690b6fae4a5f017ad8687817b25a76fbd9be",
                   "name": "dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/{{this.assets.bin.name}}"
                 }
@@ -124,7 +124,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "edc011e5ee64fc76e8004aa73d439e7cea922ab00be6c70250c5f73cf6838b1935f5d3d3c9aa65f83bfd3923751bc1a6d92be3fba64a0a09a4acb4fd8d6db4c7",
+                  "checksum": "bfc6f58cb0b87b0a2cf42d91494b914ab0997c91289599cce1704ee33fac9773e5b37b48d40c2d0fc53709c7f94cc37c26533ef7d0eb90f6db05680b2b603da0",
                   "name": "dotnet-sdk-$DOTNET_SDK_VERSION-linux-arm64.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/{{this.assets.bin.name}}"
                 }
@@ -251,7 +251,7 @@
     },
     {
       "version": "3.1-runtime",
-      "data": { "fullVersion": "3.1.15" },
+      "data": { "fullVersion": "3.1.18" },
       "variants": [
         {
           "data": { "libc": "glibc" },
@@ -268,7 +268,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "35f73dc826f08698ba7fb0f10673ac9678e97af31925fce803f5e3e602c16e00c089f909df795a61517b6c5d69ca392496d994773863fb00b1c526b19451e1e2",
+                  "checksum": "2a2af7e8a678bfca1765d647ddefa0d9ac78880216eea38c3fa71e188f7134b452d5b3f5beb481050b81f940d0d2a9e5b7acc6ecb1a9c2ca32fbb1bde0ef1216",
                   "name": "dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/{{this.assets.bin.name}}"
                 }
@@ -280,7 +280,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "0de999a51cdd53a2efa4ae3552834b540d59f598438675cb9b2ab1f16b41a64dbf0a25a2c8e65324bbdc594935046bc6ee32d8f8c25a95f607da2985f903ed55",
+                  "checksum": "6f06dbc4625fa8a0e64f650de7b285b5ffa0cd32ad8d2048fb9269b5f657e369fd28e7f27bfd05d4f422c6aa95847b5089d70760024bdf1100990dbbffce220a",
                   "name": "dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/{{this.assets.bin.name}}"
                 }
@@ -292,7 +292,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "9b36ac1479808e486c56a0cf29ac334109cb77306dfe98c72eebbebf53cc34d1e22f404850a6da41bff0a8121781ca79bba23a9c5d82d024a2f4e6c3bff29f59",
+                  "checksum": "0a106e73e3f4e1ce76ef8f89eab3f951ce999b0efa7a8c4ea2995cd89fe33566f1ee7868304c8e989da96e94af79ff128284911916f3d0d0f0421a86e8d74e54",
                   "name": "dotnet-runtime-$DOTNET_VERSION-linux-arm64.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/{{this.assets.bin.name}}"
                 }
@@ -307,7 +307,7 @@
     },
     {
       "version": "5.0-runtime",
-      "data": { "fullVersion": "5.0.6" },
+      "data": { "fullVersion": "5.0.9" },
       "variants": [
         {
           "data": { "libc": "glibc" },
@@ -323,7 +323,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "50fd448e7abbc2830015000e9e02549e3d511f4a098ded6d1948a8ca4684261e4fcfc9f2ef5f044b6f80ea536344025e17d57c1bdeb8daf65058b83ccd6fde65",
+                  "checksum": "9019858e75f73b5fd6ce0e04aeb060f61221391b6a55dbf8ed2e43f1011198252f651fb0e07b2b8e7d8d558403f2c86f6ced147c2501e36a90411bd21e521a4f",
                   "name": "dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/{{this.assets.bin.name}}"
                 }
@@ -335,7 +335,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "7aece6b763305fcf6e47e31540830797670287622ec424e689967c8974f80cefdb04961fc8cdf23c67588f3b0804b5e8291f87b06b10f2fc83d48ce0b9700d38",
+                  "checksum": "454a11d87199be6fcd5f97f28b0f9c2f15c0288dd0759dc96ac2c730697b9e6514a19bbfc06185ccb4289dd11681ea5e9cfaf6f3676040e36d21e9b90282af8d",
                   "name": "dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/{{this.assets.bin.name}}"
                 }
@@ -347,7 +347,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "2f7e8b2654655d0d816e4d2e775098c340edf5edb458af9598f33a72e340268136fe6e2516ad4cfe941d0d419fe30357756f6585bcc151110e37c710284570d8",
+                  "checksum": "00f33e9c7f6ab653872952a3bf97bd51f8c764abbcb472218d722f6d5593a80b94a15c1a6fdefd0a4f8ed64874754903c3ab40e1761cff93bcaff3b5da82c47b",
                   "name": "dotnet-runtime-$DOTNET_VERSION-linux-arm64.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/{{this.assets.bin.name}}"
                 }
@@ -362,7 +362,7 @@
     },
     {
       "version": "3.1-aspnet",
-      "data": { "fullVersion": "3.1.15" },
+      "data": { "fullVersion": "3.1.18" },
       "variants": [
         {
           "data": { "libc": "glibc" },
@@ -379,14 +379,14 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3c4fcbf9eab630f25605cfcbe8c55af452d4b10cc054257e26dfa4bdb09fd025c35cc9ea12dbcbc7c420946e618b9e8ba50ca81525b5055c79323bb7e94b5544",
+                  "checksum": "373d8314f267c9c49df866e14eb98b0600a7e2a68157f84b0c08762417bd8ebace6b2acf214c5749ad1c1b00989b9e04bfa9f1d802269c12b8bd2ff8434d7f86",
                   "name": "aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/{{this.assets.bin.name}}"
                 },
                 "runtime": {
-                  "fullVersion": "3.1.15",
+                  "fullVersion": "3.1.18",
                   "bin": {
-                    "checksum": "35f73dc826f08698ba7fb0f10673ac9678e97af31925fce803f5e3e602c16e00c089f909df795a61517b6c5d69ca392496d994773863fb00b1c526b19451e1e2",
+                    "checksum": "2a2af7e8a678bfca1765d647ddefa0d9ac78880216eea38c3fa71e188f7134b452d5b3f5beb481050b81f940d0d2a9e5b7acc6ecb1a9c2ca32fbb1bde0ef1216",
                     "name": "dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz",
                     "url": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/{{this.assets.runtime.bin.name}}"
                   }
@@ -399,14 +399,14 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f1bc75c3af3308dd4d1448570a85a2f5ab9d21df474965b7216452e9dccd6f10028c18e3e291864f8f19b18e1f203c80a9fdcacb303b5a5763d7579cdb014cfe",
+                  "checksum": "be29a7611941d9b20d5d3ece64d271bddf6814968b5103ce3c2342ba24bf0382eed3625713ce89957fa15671403af16ccb588397fc0b27e7f028952213e08db6",
                   "name": "aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/{{this.assets.bin.name}}"
                 },
                 "runtime": {
-                  "fullVersion": "3.1.15",
+                  "fullVersion": "3.1.18",
                   "bin": {
-                    "checksum": "0de999a51cdd53a2efa4ae3552834b540d59f598438675cb9b2ab1f16b41a64dbf0a25a2c8e65324bbdc594935046bc6ee32d8f8c25a95f607da2985f903ed55",
+                    "checksum": "6f06dbc4625fa8a0e64f650de7b285b5ffa0cd32ad8d2048fb9269b5f657e369fd28e7f27bfd05d4f422c6aa95847b5089d70760024bdf1100990dbbffce220a",
                     "name": "dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz",
                     "url": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/{{this.assets.runtime.bin.name}}"
                   }
@@ -419,14 +419,14 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "574db7a64e6afe6e55dbc4f95b5d87bfde9cec973e9501f8b8ce6a11383edc97b600a3e926cda53a3711d2d7bc195dbe5d77ecb954c8d09a6b332b45c07e6512",
+                  "checksum": "82f5513866138626bf12dc1f5e48684ada96870ab93acef0bf8a9ef0f05988bbea6bdbad02bd52b2c394ca9fdcdc8b924b5bba7994bfe1c034913a0d77ffd00a",
                   "name": "aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm64.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/{{this.assets.bin.name}}"
                 },
                 "runtime": {
-                  "fullVersion": "3.1.15",
+                  "fullVersion": "3.1.18",
                   "bin": {
-                    "checksum": "9b36ac1479808e486c56a0cf29ac334109cb77306dfe98c72eebbebf53cc34d1e22f404850a6da41bff0a8121781ca79bba23a9c5d82d024a2f4e6c3bff29f59",
+                    "checksum": "0a106e73e3f4e1ce76ef8f89eab3f951ce999b0efa7a8c4ea2995cd89fe33566f1ee7868304c8e989da96e94af79ff128284911916f3d0d0f0421a86e8d74e54",
                     "name": "dotnet-runtime-$DOTNET_VERSION-linux-arm64.tar.gz",
                     "url": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/{{this.assets.runtime.bin.name}}"
                   }
@@ -442,7 +442,7 @@
     },
     {
       "version": "5.0-aspnet",
-      "data": { "fullVersion": "5.0.6" },
+      "data": { "fullVersion": "5.0.9" },
       "variants": [
         {
           "data": { "libc": "glibc" },
@@ -458,14 +458,14 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "d00b6198ace6aa2b9b164297be42cd442099fd128d3409e17d20d3d1a67d2ab9e2350d3ceea7260101b60247402d828be09b714cd431e7211fd9dee49fba35c7",
+                  "checksum": "ea8d15c3db26b11fe1941a15996532906a6eee3ee281ab9b3153cbac79d108f59979464741a3bfc5b7cf959a030e70cd2d3a2150f49c2334eb788f1778cd1b5b",
                   "name": "aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/{{this.assets.bin.name}}"
                 },
                 "runtime": {
-                  "fullVersion": "5.0.6",
+                  "fullVersion": "5.0.9",
                   "bin": {
-                    "checksum": "50fd448e7abbc2830015000e9e02549e3d511f4a098ded6d1948a8ca4684261e4fcfc9f2ef5f044b6f80ea536344025e17d57c1bdeb8daf65058b83ccd6fde65",
+                    "checksum": "9019858e75f73b5fd6ce0e04aeb060f61221391b6a55dbf8ed2e43f1011198252f651fb0e07b2b8e7d8d558403f2c86f6ced147c2501e36a90411bd21e521a4f",
                     "name": "dotnet-runtime-$DOTNET_VERSION-linux-arm.tar.gz",
                     "url": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/{{this.assets.runtime.bin.name}}"
                   }
@@ -478,14 +478,14 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "07fd5ab0b62e3d68a3099b76e1236550d86a1ec24150a09284d37b58055786595b182662671f0d4602545bfa404da8be0f9ab96036352dca28dbfef0048bb22d",
+                  "checksum": "67ac99b8f631684961aa2e887ed5d6b9cc301b06a1842ac212791860bf6de145831228df5f57eca8a97e16e569e7b5a308fd20d82f11569c375c689fc932dfff",
                   "name": "aspnetcore-runtime-$ASPNETCORE_VERSION-linux-x64.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/{{this.assets.bin.name}}"
                 },
                 "runtime": {
-                  "fullVersion": "5.0.6",
+                  "fullVersion": "5.0.9",
                   "bin": {
-                    "checksum": "7aece6b763305fcf6e47e31540830797670287622ec424e689967c8974f80cefdb04961fc8cdf23c67588f3b0804b5e8291f87b06b10f2fc83d48ce0b9700d38",
+                    "checksum": "454a11d87199be6fcd5f97f28b0f9c2f15c0288dd0759dc96ac2c730697b9e6514a19bbfc06185ccb4289dd11681ea5e9cfaf6f3676040e36d21e9b90282af8d",
                     "name": "dotnet-runtime-$DOTNET_VERSION-linux-x64.tar.gz",
                     "url": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/{{this.assets.runtime.bin.name}}"
                   }
@@ -498,14 +498,14 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "40a09a9ff07b078cff17da6d0bfeb427c99c64f15135111831eef94c9d8c6274e9c5f3787c7b7652113e93af2547ed41b26b9d59fb55f28f9aa69cf90e804d0e",
+                  "checksum": "7bad5fa5fb8dc7eba9babc06d68b170e127df8d5729adf26530b2858aa4f411ca35c4641da0b0b13c7340fc5843e3b1d70b2038eabfca64d598e06fcf1b47edb",
                   "name": "aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm64.tar.gz",
                   "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/{{this.assets.bin.name}}"
                 },
                 "runtime": {
-                  "fullVersion": "5.0.6",
+                  "fullVersion": "5.0.9",
                   "bin": {
-                    "checksum": "2f7e8b2654655d0d816e4d2e775098c340edf5edb458af9598f33a72e340268136fe6e2516ad4cfe941d0d419fe30357756f6585bcc151110e37c710284570d8",
+                    "checksum": "00f33e9c7f6ab653872952a3bf97bd51f8c764abbcb472218d722f6d5593a80b94a15c1a6fdefd0a4f8ed64874754903c3ab40e1761cff93bcaff3b5da82c47b",
                     "name": "dotnet-runtime-$DOTNET_VERSION-linux-arm64.tar.gz",
                     "url": "https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_VERSION/{{this.assets.runtime.bin.name}}"
                   }

--- a/contracts/sw.stack/golang/contract.json
+++ b/contracts/sw.stack/golang/contract.json
@@ -4,8 +4,8 @@
   "name": "Go v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "1.16.6",
-    "versionList": "`1.16.6 (latest)`, `1.15.14`",
+    "latest": "1.16.7",
+    "versionList": "`1.16.6 (latest)`, `1.15.15`",
     "introduction": "Go (a.k.a., Golang) is a programming language first developed at Google. It is a statically-typed language with syntax loosely derived from C, but with additional features such as garbage collection, type safety, some dynamic-typing capabilities, additional built-in types (e.g., variable-length arrays and key-value maps), and a large standard library.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/golang/logo.png"
   },
@@ -28,7 +28,7 @@
   },
   "variants": [
     {
-      "version": "1.16.6",
+      "version": "1.16.7",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -39,7 +39,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c4817aabad06d8cae80dc0f4e6a74ccb1dbae3e9a2f513197bf419dbfc03e58f",
+                  "checksum": "5488d3cfb1c0f11deb7c765a64eb6d0c9d7d55faf000a7062bd06c021fc8b71f",
                   "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                   
@@ -52,7 +52,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "9ac607f5e30fcbe7efd967288dd6a96da0e4e233dd8319a186f0d1b44484b41f",
+                  "checksum": "f33dbfac99b6369a346bab9396f1def9ccbab87d44210dea76bef773ea8332ed",
                   "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -64,7 +64,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "70e463519052665abbe9bb3100aa29cb80f7a121ed8747d5a8982fece7a417a5",
+                  "checksum": "09d132579e084da98f2125ba99e34c24f0d73f5ade09507d27cf822508e3c6c7",
                   "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -76,7 +76,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "dd97714cbfb793035dbac5396aba35fa6ca7348856aec96ff85ae108b3f13121",
+                  "checksum": "0d54e410e0f66ae372f7ae130063d2b5174fcfa684fc36c5389339348c8d4afb",
                   "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -88,7 +88,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3c5001104d7aea2abbe7e39d1d6c8981aeafa44a942feee00f2bfdbb9251da64",
+                  "checksum": "d3b8a40f64ef8ac944e300da3b409f0fd93c92d7a09046862835f631661b1c0d",
                   "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -114,7 +114,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "b1ca342e81897da3f25da4e75ae29b267db1674fe7222d9bfc4c666bcf6fce69",
+                  "checksum": "b2973ceeae234866368baf9469fb7b9444857e50dc785ba879d98a0aa208a12b",
                   "name": "go$GO_VERSION.linux-armv6l.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -126,7 +126,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "32fcc0b7f3188286ae2f9c94c825a9f12e650c4ee5542333a2f24b630d58a374",
+                  "checksum": "fb83b7dfaf2c21a179f23a8115d26912edd19b54081588513529792a29253ffb",
                   "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -138,7 +138,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d",
+                  "checksum": "7fe7a73f55ba3e2285da36f8b085e5c0159e9564ef5f63ee0ed6b818ade8ef04",
                   "name": "go$GO_VERSION.linux-amd64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -150,7 +150,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "9e38047463da6daecab9017cd0599f33f84991e68263752cfab49253bbc98c30",
+                  "checksum": "63d6b53ecbd2b05c1f0e9903c92042663f2f68afdbb67f4d0d12700156869bac",
                   "name": "go$GO_VERSION.linux-arm64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -162,7 +162,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "33d028b6d2a4abeb74cccd55024500ae49d5edfb08a30665db0b49cd1052c37e",
+                  "checksum": "5c0c8891fa88993f2193fbc9dd5cca6c250c89aa8c12bbaa382b6ff38139bcc3",
                   "name": "go$GO_VERSION.linux-386.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -176,7 +176,7 @@
       ]
     },
     {
-      "version": "1.15.14",
+      "version": "1.15.15",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -187,7 +187,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c6597fed47e174c4c4718fda581e1a2abe4d4a1931da368197cd8f9a3b43d337",
+                  "checksum": "ccf774e180854f7327ade2232a31100c89cc2c3031c3f66604be76a3c8f5bd60",
                   "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -199,7 +199,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "790a91909d26564aa96d65cd776f0bde3b917e4be2d0d3359113f6b7d6a3455a",
+                  "checksum": "e74e7632eb29b2d86e4ffb5f2139a5604ea5f22bf2228bd1aa5e62903e4b3829",
                   "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -211,7 +211,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "7b0847c22a808fe840aa15272d0d3d52ed34163b517c561aaccc679f323a78e6",
+                  "checksum": "41e14203a77e39f407411c5ccade7692648d74c9b21cea926b97335928fef139",
                   "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -223,7 +223,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "05e57b158863bfafac6bc6b27bc8071c42befdeeb5c6f3d292b45c54f685666c",
+                  "checksum": "53f9e0323b54c10c8eda8de7dd6514a40772caf3c8f53780867d40902266e4e6",
                   "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -235,7 +235,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "ed44209ffc31f2b89cb0a952aca0980b615231bbbfb07b22a7d222776a610354",
+                  "checksum": "a717bb3426310f16cf6d5592e38b1ec0a3e17c4b4fbf71eabb11f80e7ce1a63d",
                   "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -261,7 +261,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a40fe975caf82daef311e22902eb4aeda1f0bd63a782c1ebd81911abed6c187b",
+                  "checksum": "7192603af50afb23c9d8cd14d2b2c19e0985a34d3eca685fa098df7893000d19",
                   "name": "go$GO_VERSION.linux-armv6l.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -273,7 +273,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "2ac602e00f117fbee3d4bb159976e643f7c1bdab46646b0a38182cfa26576ceb",
+                  "checksum": "d9fb73cdb701744b36fd6766dca947efd3c28d12a7795204000c54fc53464dde",
                   "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
                 }
@@ -285,7 +285,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "6f5410c113b803f437d7a1ee6f8f124100e536cc7361920f7e640fedf7add72d",
+                  "checksum": "0885cf046a9f099e260d98d9ec5d19ea9328f34c8dc4956e1d3cd87daaddb345",
                   "name": "go$GO_VERSION.linux-amd64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -297,7 +297,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "84e483d1ec7dae591f28f218485f8f67877412e24b8cea626bebf25b6d299c7f",
+                  "checksum": "714abb01af210473dd6af331094ad6847162eff81a7fc7241d24f5a85496c9fa",
                   "name": "go$GO_VERSION.linux-arm64.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }
@@ -309,7 +309,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "0216746103b8da20b23f91a86795bcf72e12428b2d07dfd3279a14b070ceaa74",
+                  "checksum": "3310fb0e48b0907bb520f6e3c6dcff63cc0913b92a76456f12980d0eb13b77d4",
                   "name": "go$GO_VERSION.linux-386.tar.gz",
                   "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
                 }

--- a/contracts/sw.stack/node/contract.json
+++ b/contracts/sw.stack/node/contract.json
@@ -4,8 +4,8 @@
   "name": "Node.js v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "16.6.1",
-    "versionList": "`16.6.1 (latest)`, `14.17.4`, `12.22.4`",
+    "latest": "16.6.2",
+    "versionList": "`16.6.2 (latest)`, `14.17.5`, `12.22.5`",
     "introduction": "Node.js is a software platform for scalable server-side and networking applications. Node.js applications are written in JavaScript and can be run within the Node.js runtime on Mac OS X, Windows, and Linux without changes.\n\nNode.js applications are designed to maximize throughput and efficiency, using non-blocking I/O and asynchronous events. Node.js applications run single-threaded, although Node.js uses multiple threads for file and network events. Node.js is commonly used for real-time applications due to its asynchronous nature.\n\nNode.js internally uses the Google V8 JavaScript engine to execute code; a large percentage of the basic modules are written in JavaScript. Node.js contains a built-in, asynchronous I/O library for file, socket, and HTTP communication. The HTTP and socket support allows Node.js to act as a web server without additional software such as Apache.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/node/logo.png"
   },
@@ -31,7 +31,7 @@
   ],
   "variants": [
     {
-      "version": "16.6.1",
+      "version": "16.6.2",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -42,7 +42,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3ee222f8a2853fcbe7a4d1eacc51a45affde9312a802fda497a561fccd89b117",
+                  "checksum": "8101f73d90d271bd4bc8d5fb10e5a1fec55e0346a7d47ae3d5b44d0d79c6a068",
                   "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -54,7 +54,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "6f2264af37c77eb39aa50d2d26efd80dc4ed082d9decf28122d857367bef15d2",
+                  "checksum": "f005980a6b4f99dd64a0678602e5a9dda6c924d143a67739e7ac14bf0d150487",
                   "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -66,8 +66,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "44139e221a4134abb8124f79cc4838c0cb86fcd0178cc3f88e92aa60354a9643",
-                  "name": "node-v$NODE_VERSION-linux-aarch64-alpine.tar.gz",
+                  "checksum": "a8d1f54344d1ea78a1bb35b6980f7c2ff4a72e0f6804806186cbaf8062ee2688",
+                  "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -78,8 +78,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "20e2c33cfe65f8c296414ed6169732b1355b28368a77c8598a97a6595edd0c9e",
-                  "name": "node-v$NODE_VERSION-linux-armv6hf-alpine.tar.gz",
+                  "checksum": "789c21157a1f66bdfcedecd2f3e348869f479cc41e27cf409540bebc8a9125c6",
+                  "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -90,8 +90,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3cf27cfef3f04b63cea9bf6e0473195575dba7c94ba3069aab604a1d0fc19b36",
-                  "name": "node-v$NODE_VERSION-linux-armv7hf-alpine.tar.gz",
+                  "checksum": "ce2031cbc29e0ed848c409f6d24a503e6df7fc733d92ba2ecb78548225b6ea64",
+                  "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -116,7 +116,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "04268fda50beb3aa116e150adcd3175cde17166b1f40079765da281fa73cc6cb",
+                  "checksum": "1ba5287c941cef2da53c0d80db7db7124971b1c933f222ca7f2eb833e1817f35",
                   "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -128,7 +128,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "e7e4149626ccd0653783ee8aef81eb50fa7ada2f9f7cbc031969b3b1ac3ffa6b",
+                  "checksum": "913913f62416b96dee5f463b54e1adebaf669dd2ff3b047d6290deadc3003d97",
                   "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -140,7 +140,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c1579451e17c405212e2c32a471e977628dc021f3d126e689538bff803f3d143",
+                  "checksum": "1a9e1f1df6fdc59c7060bafc5e31317dccd57d3b16b3268ae504a1d7505250a7",
                   "name": "node-v$NODE_VERSION-linux-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -152,7 +152,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "ecab5720035b6bb97564b05df527d49a37489dcba6a244c0f1c7c801bb2755f7",
+                  "checksum": "c51a94f28a29c390d20445d9b334a9808d3166bd244ebc03852d23c0b17a93ca",
                   "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -164,7 +164,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "b74228cfcaeef4a0f7bc3846f7aca0860216055ffc4feb7bc2a2d1f8e9d8d06e",
+                  "checksum": "8ff90a856e1bdfa4c6cd7390d597b4a1caeda5974186cb9f17df67b2b0af06bb",
                   "name": "node-v$NODE_VERSION-linux-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -178,7 +178,7 @@
       ]
     },
     {
-      "version": "14.17.4",
+      "version": "14.17.5",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -189,7 +189,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "8ca8396df6ba2e81bdb8d8fb758b0b48e31482f2a8ded74a572ace04db17b081",
+                  "checksum": "a82e5f36d753e3c3b999fed6aa98f9dc72da6773e8007226e6d1fb50937c294d",
                   "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -201,7 +201,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "09a592e5cd60f0fafa730fd797c1abb5a5920f76558045ac71a122a33af6b27b",
+                  "checksum": "4aa81e0741fabba9c50b4d24ace66c96c2913c5da31902c99a490f757bf670ba",
                   "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -213,8 +213,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "63958798dba6d8af368e55e4551ebb090fc38002a98cf81edf12ffdb653bd0d9",
-                  "name": "node-v$NODE_VERSION-linux-aarch64-alpine.tar.gz",
+                  "checksum": "43ffa255d18fb7168c97328f415efa90d80e0d9063028e9bac0d2b9d825ed63c",
+                  "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -225,8 +225,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "fad8e92b560e16e7fa7d3a051b62a68d0db8772f44ac7ca899d76baa79cb8e09",
-                  "name": "node-v$NODE_VERSION-linux-armv6hf-alpine.tar.gz",
+                  "checksum": "a7cf240c99886881aa5f91cba4f8b0946500ff8ba048ab210564d8724b40b8ea",
+                  "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -237,8 +237,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f2dd0a53cb5d60f0068ca11204030553dbe8dc75e5e736820fd644b858cdb8a0",
-                  "name": "node-v$NODE_VERSION-linux-armv7hf-alpine.tar.gz",
+                  "checksum": "07f54daded8ec3f681b413cb06385f82edd9deabe092d9a4ce6a60d0f60ade7b",
+                  "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -263,7 +263,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "e5452a8786ea018fe9c588ffe05ca4b4b66d6a7cda1f6352bda9bd0d0421e325",
+                  "checksum": "c79cc802f6034e9a9583ccbf8ccd17a0d8e0942c136011c0f4c3a475d46614be",
                   "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -275,7 +275,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "99cc7115a30fe62abf06145d57b314092c9bf27499da85413a12f50140199619",
+                  "checksum": "dc04c7e60235ff73536ba0d9e50638090f60cacabfd83184082dce3b330afc6e",
                   "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -287,7 +287,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "88b130c8f08a2baafb4e4c953ad46ba69cc60210da7d95c558c7ae3456beb825",
+                  "checksum": "bee6d7fb5dbdd2931e688b33defd449afdfd9cd6e716975864406cda18daca66",
                   "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -301,7 +301,7 @@
       ]
     },
     {
-      "version": "12.22.4",
+      "version": "12.22.5",
       "variants": [
         {
           "data": { "libc": "musl-libc" },
@@ -313,8 +313,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "8f3ddb86ef9f1e57144f768a303f4cfa76cae52478167c77c8b9a8675237ee55",
-                  "name": "node-v$NODE_VERSION-linux-armv6hf-alpine.tar.gz",
+                  "checksum": "8e01550dc2bf33e6a43e472fc76bd0bc6b7ccdb53ea5fa6464d57fa8c95b6a8d",
+                  "name": "node-v$NODE_VERSION-linux-alpine-armv6hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -325,7 +325,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "b9ccb7c374018c2fbdac6e0a135cc0985e79a09d5e78024b36ad0f7105ffacac",
+                  "checksum": "cd64f152f325aed5112e700619a5aedc180aa36191a146bf695889d2990413ce",
                   "name": "node-v$NODE_VERSION-linux-alpine-amd64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -337,7 +337,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "44620b6665812ce044b2a62ca17b37e9af8bccb80e0426b173f25f636d3db542",
+                  "checksum": "87c5a77770477260c6ab456fb8199e75e93a70fbc0c05f65e1705230e949a82a",
                   "name": "node-v$NODE_VERSION-linux-alpine-i386.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -349,8 +349,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "d16a59015ad39ed0efd0966493ccd01a5e7e0fe00bea0e052a98834282465852",
-                  "name": "node-v$NODE_VERSION-linux-aarch64-alpine.tar.gz",
+                  "checksum": "348baec5f5f4daeee856d224056035b052f56605900a8ccdaded1985dac4ba8f",
+                  "name": "node-v$NODE_VERSION-linux-alpine-aarch64.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -361,8 +361,8 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "89a3b037cce29679d7760ef829e7ad91db973b56ce3ab54566945dff2e562116",
-                  "name": "node-v$NODE_VERSION-linux-armv7hf-alpine.tar.gz",
+                  "checksum": "fc4ce574a3b28dfffeed28e0437889852bdbb9591a9455d9928444a0aca04140",
+                  "name": "node-v$NODE_VERSION-linux-alpine-armv7hf.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/node/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
               },
@@ -387,7 +387,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "8d5164221a89c3ae4e7cbb5a5bb5b22fd3bf87d058295fe97e1b1e3376fafe33",
+                  "checksum": "0b271c210e26ffb20728dfffa02df47aca896c849968964e2019da67832ee839",
                   "name": "node-v$NODE_VERSION-linux-armv7l.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -399,7 +399,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "2dde8a22ad15b8e270fee42ab40de71aed7bd97c10e7d04cd826430400fff601",
+                  "checksum": "89eaf038c41439dcbc543d1783adc0e9f38ddf07c993c08e111d55fe35dadc21",
                   "name": "node-v$NODE_VERSION-linux-x64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }
@@ -411,7 +411,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "c104dff52409d27836f7c4529c7f3cce6c76a521b8b834e338bcbf6eed4abc18",
+                  "checksum": "bfb436a87142e9dc73ed675c81c267490e575f9abfbbc7fa5db227a2ab6b555c",
                   "name": "node-v$NODE_VERSION-linux-arm64.tar.gz",
                   "url": "http://nodejs.org/dist/v$NODE_VERSION/{{this.assets.bin.name}}"
                 }

--- a/contracts/sw.stack/python/contract.json
+++ b/contracts/sw.stack/python/contract.json
@@ -4,21 +4,21 @@
   "name": "Python v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "3.9.5",
-    "versionList": "`3.9.5 (latest)`, `3.8.10`, `2.7.18`, `3.7.9`, `3.6.12`, `3.5.10`",
+    "latest": "3.9.6",
+    "versionList": "`3.9.6 (latest)`, `3.8.11`, `2.7.18`, `3.7.11`, `3.6.14`, `3.5.10`",
     "introduction": "Python is an interpreted, interactive, object-oriented, open-source programming language. It incorporates modules, exceptions, dynamic typing, very high level dynamic data types, and classes. Python combines remarkable power with very clear syntax. It has interfaces to many system calls and libraries, as well as to various window systems, and is extensible in C or C++. It is also usable as an extension language for applications that need a programmable interface. Finally, Python is portable: it runs on many Unix variants, on the Mac, and on Windows 2000 and later.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/python/logo.png"
 
   },
   "assets": {
     "pip": {
-      "version": "21.0.1"
+      "version": "21.2.3"
     },
     "setuptools": {
-      "version": "56.0.0"
+      "version": "57.4.0"
     },
     "dbus": {
-      "version": "1.2.16"
+      "version": "1.2.18"
     },
     "test": {
       "main": "test-stack@python",
@@ -38,7 +38,7 @@
   ],
   "variants": [
     {
-      "version": "3.9.5",
+      "version": "3.9.6",
       "assets" : {
         "pip": {
           "command": "pip3"
@@ -71,7 +71,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "348192a9896edb7c8d95ec46da361c0f97f02ab14d38711472b6fdc63465a60b",
+                      "checksum": "12d11d0a92a8e44d11ffcfe4d9be6c7472721b6763af98137817b188aca6dc8d",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -98,7 +98,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "2d6e4ba7b93976a35c8703c60d6bf2e2e7cfd5eaaa52cb3bbdab34a16cf4a37c",
+                      "checksum": "fd495d5dd7b4d3167df6a7a693a77b0e2be6d0cbde9ebe5b8006d4b894729fc9",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-amd64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -125,7 +125,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "8acab98630bf7b246c004b8a04902da09be92c7f4640736fc1ee0d3e907d81a5",
+                      "checksum": "86c8117eb5a56cc28e104315f279c7c84eaeeb598797eb514f6acfe260f5ba07",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-i386-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -152,7 +152,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "0498d4a6ac61cecd01d95f43000e2270fa573a86e1f32cd17284fb54587e15f7",
+                      "checksum": "1cbd26a8137e5c324a29f4783e8a9ce3fdb94eebe746b45d7b5de1dc8a70e7a3",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-aarch64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -179,7 +179,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "72a27e265f971c87d046778811835816afdacd87ae58619525fcacf06e102b8e",
+                      "checksum": "af856e7ddd9e60393517f7eb9e8d3a535a74f4d6c9518482267314744b2b24f3",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv7hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -211,7 +211,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "1692a20f7193bdc04ede5051cf35f0a98d559d010e050966874765c7d855fdf7",
+                  "checksum": "9874913f5725b7aa21fbe41cff405872ef1f2f3be8d63e9b1673eacec489fcd3",
                   "name": "Python-$PYTHON_VERSION.linux-armv6hf-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -223,7 +223,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a978f57e3e95f8f1a96370a9d719227f7303264b0968e9fd3f3846a9a738af59",
+                  "checksum": "b93ade16bf1e18f2d3a4e16b4a4accd8186cf9fdb252dda654c466407f7f8383",
                   "name": "Python-$PYTHON_VERSION.linux-armv7hf-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -235,7 +235,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f653f747bce6920e97f50beec2cd3caef17158c71f520c9c41119c702777192c",
+                  "checksum": "66202855c698681192d72b4b39d87f5e9db44ec3eacd15d6bbba4193f56add75",
                   "name": "Python-$PYTHON_VERSION.linux-amd64-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -247,7 +247,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "e2389bad61947f2c18d43707adfa76c9d6a0ccbe69445e8f1466016e49d362cf",
+                  "checksum": "ba76702f8d4b6f506624fdf3cdef0c1a9c3a8324607fec84071ba557c5485e9b",
                   "name": "Python-$PYTHON_VERSION.linux-aarch64-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -259,7 +259,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3f2c9c61f0d988a46622e2e35ec2d7135f218c64eb31c72c046213cabd11b721",
+                  "checksum": "245096be7d675b848121018fe1cac9c3381b72cdba0f23e05a39c3b1465690ab",
                   "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -267,25 +267,13 @@
               "requires": [
                 { "type": "arch.sw", "slug": "i386" }
               ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "3f2c9c61f0d988a46622e2e35ec2d7135f218c64eb31c72c046213cabd11b721",
-                  "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "i386-nlp" }
-              ]
             }
           ]
         }
       ]
     },
     {
-      "version": "3.8.10",
+      "version": "3.8.11",
       "assets" : {
         "pip": {
           "command": "pip3"
@@ -318,7 +306,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "94babc2629872a960d4202b1c832dcaa5b4a37f9e190dca843a61e9622b7ee3a",
+                      "checksum": "b584bba729a032297f83abf33692b00677e52d26a3ea7b1e5c05d46f47b9a79e",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -345,7 +333,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "27d1c44191df5c8b1a50c612c1308c5c1e4919511c4bda7116429c64e67e846b",
+                      "checksum": "ca125e9eb52942d8e09b297d762b30e7b78020bfb0a1d6971f9e0074daeb40ac",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-amd64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -372,7 +360,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "4fb9f6595937830d5b5024637b34356aaaaf686fce2c0e15cd40a30582dfc264",
+                      "checksum": "f2e42f291f7fd922573b77b2ee1fb30b39f84556b66a721faebae4086113f0db",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-i386-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -399,7 +387,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "9ff4b63ab44774d25405e4d2eb1b0d8c388e6d7c3c388602dffca4b3669066da",
+                      "checksum": "3da811d6def26c4bf6653b556adacb0b29ef1efee2a222166d422aff2d6cf2bc",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-aarch64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -426,7 +414,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "6297c333a4e15a356ac02cdde159b669b726d279e1281bd6273d1947ef160c85",
+                      "checksum": "9ad9d14e242a96e861878c1314e2ed86e5e9d082b43f00e523d93234b0f34789",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv7hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -458,7 +446,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "a99f3118a5015acbf4afbe0766145c9132ca3efcd1032744115756ca424dbf8e",
+                  "checksum": "c3b748fcd762f565e4ebbcc3736a9e268a87898ac09d7e4c2eeb650675eb350b",
                   "name": "Python-$PYTHON_VERSION.linux-armv6hf-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -470,7 +458,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "70b4068f50acb7e402194c3babd46ae39272dbe65a41a0f824bf1759511c290f",
+                  "checksum": "023cf5f725806026f196bce5d9ec2d0827b39d1b913393701777d394bbd1e051",
                   "name": "Python-$PYTHON_VERSION.linux-armv7hf-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -482,7 +470,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "30ba78e46c14b23fdb466e1e2e9ec542645e1694f217821859b0d2d9635b3939",
+                  "checksum": "aee7d4a5c19d4bfac8eb692f1c514b6eacde86a4a85c5f621d9ca2c7263c00cb",
                   "name": "Python-$PYTHON_VERSION.linux-amd64-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -494,7 +482,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "91bdd24b13f40e97a02a8eab755e2228a6af74e3876ca02b85f9b39441c9009a",
+                  "checksum": "42e0ff815b6a33135cb8de4cc2eb1820d316558b75ce730ccea0ace151c95d06",
                   "name": "Python-$PYTHON_VERSION.linux-aarch64-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -506,7 +494,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "43c50480760b93a79a71d853418978a91501c39db176afe82b99617d7d03ab98",
+                  "checksum": "bf9fe746aaef71b7d31fc1058ff759ef9832c67e67e47790eb506c1572e98715",
                   "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -514,25 +502,13 @@
               "requires": [
                 { "type": "arch.sw", "slug": "i386" }
               ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "43c50480760b93a79a71d853418978a91501c39db176afe82b99617d7d03ab98",
-                  "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "i386-nlp" }
-              ]
             }
           ]
         }
       ]
     },
     {
-      "version": "3.7.9",
+      "version": "3.7.11",
       "assets" : {
         "pip": {
           "command": "pip3"
@@ -565,7 +541,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "3901fa8b7971b70917b20babe12d6d8bec4a957b0a02993ce1a30ec9c7934395",
+                      "checksum": "48e89f0deb6e14cee7c593740283808448a19c8e3bfc03d1e0e9eeb2e9b38e39",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -592,7 +568,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "858b9a1bfb0deb4fbfebf6c71a5d7b6b6db6ef11ccaea59266521735f81d05d0",
+                      "checksum": "2dbf1022755318b5f63d697f884fb7adc786b0dc861d3c754941decb53fb1094",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-amd64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -619,7 +595,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "948729fb9592d792142d3d0b77bcc6324c97a4ac62df7460d28466a723627375",
+                      "checksum": "8f2d55453aa4b4310c8956e7b79ab4a3b86561e782f4c5f74226eed44b898d44",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-i386-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -646,7 +622,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "f7702ae692d0acb731b9f0a5fa40d4db00e4a3a73d68a2a3b0a975d9484d7fec",
+                      "checksum": "01eec2a30369f63349f25be13f674e3f3b3147fef0b0b9f8dcb3c745dbdd681f",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-aarch64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -673,7 +649,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "ee7f5ec1290f559e8807b997d3f096d78fb0215df4f889af9b0a960579af2759",
+                      "checksum": "97bc0ec4e0efe8a7c56e2507f9956fd6a675225bf7c1dcfc17e86ce60a408f9d",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv7hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -705,7 +681,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "f6d03490ed2eccab4b877eef3d0747803bdf297b4a93cd7a2b6be934b0aa59bf",
+                  "checksum": "99c8b55d2198df2557fb660169a8d4182d24347cf54bece083b0747061537c1b",
                   "name": "Python-$PYTHON_VERSION.linux-armv6hf-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -717,7 +693,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "41d30a89ec9efa76be08d7485d82df0a1d0a4d7ff496cea3dd3a7bcb68d840bc",
+                  "checksum": "882ac11310d9f88067d97848eadda2f2f39bc46c118cdfc81cdf9ba90d5d85c8",
                   "name": "Python-$PYTHON_VERSION.linux-armv7hf-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -729,7 +705,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "1a5fed1fdbb5a15591a73e5be2b6872dde3b4499c001d9aa17b9c1620d90266b",
+                  "checksum": "2e21cf513e176a959589a5cdcc4de5d27e386b1d58d83f089e8c3ed7f76e8ae1",
                   "name": "Python-$PYTHON_VERSION.linux-amd64-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -741,7 +717,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "3636d4d54b8a1718b60d9f8bee3c608cf0d26545ff66aef340bfe8c761e15ab1",
+                  "checksum": "98ed54f7c6cfff28c71331df296a0ba36aab76be2af4adda9e2b9b6092089386",
                   "name": "Python-$PYTHON_VERSION.linux-aarch64-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -753,7 +729,7 @@
             {
               "assets": {
                 "bin": {
-                  "checksum": "fc6533fa41c20575b6b9d32814cf80fb3ab4a9066aa77e4fe2137934e58b5fb4",
+                  "checksum": "e8060eb03efb3d0dc7a6a3395f770777745cb3c91e94480fa5fe41f48ef7f3a4",
                   "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
                   "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                 }
@@ -761,25 +737,13 @@
               "requires": [
                 { "type": "arch.sw", "slug": "i386" }
               ]
-            },
-            {
-              "assets": {
-                "bin": {
-                  "checksum": "fc6533fa41c20575b6b9d32814cf80fb3ab4a9066aa77e4fe2137934e58b5fb4",
-                  "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
-                  "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
-                }
-              },
-              "requires": [
-                { "type": "arch.sw", "slug": "i386-nlp" }
-              ]
             }
           ]
         }
       ]
     },
     {
-      "version": "3.6.12",
+      "version": "3.6.14",
       "assets" : {
         "pip": {
           "command": "pip3"
@@ -812,7 +776,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "2391f85ac43cece0b49d8b2708af43b4f2bc220b99dfd28f063a560913218c8f",
+                      "checksum": "be27e11b6ee3bcbb485ab1ad52cfaf2f61da563a6dcab4eb3121a85f3100a9c2",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv6hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -839,7 +803,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "ccc5c447800592224f88cdd8792df2725cbb04dc93dc1412a1033ffe73f30707",
+                      "checksum": "892ed63eab73348c3529fe7d08a66c63c9cf95bc0bccd4152351810dc004a6ed",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-amd64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -866,7 +830,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "e1a581532bcf6f12525b843f5fad8307a100c80e80c900addb3e9ef3e7a7a10b",
+                      "checksum": "121e04b51c4975b0298b0c47669a734aabda001a129f0cb0913318d527700d91",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-i386-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -893,7 +857,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "0f2f79cec6173c11dd094e0da3b4b93148b6c7058fb7a8c3cb64acc96e29e368",
+                      "checksum": "61b79d021947e81c8be65e6ba1c3bbc6b0bc13702cab4457837e488eb65588e8",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-aarch64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -920,7 +884,7 @@
                   ],
                   "assets": {
                     "bin": {
-                      "checksum": "9ea800721595b573ee89cb20f4c28fa0273cf726a509bc7fcd21772bd4adefda",
+                      "checksum": "bc73e84b3fc16ddd542c60d697faddfe1795acf5a4930aa61b194c7fc1fc467e",
                       "name": "Python-$PYTHON_VERSION.linux-alpine-armv7hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -950,7 +914,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "274862c13dd40efe475f96a74c2ded3a83fd3bd497e67f37430e3b2e8dc6b129",
+                      "checksum": "8ac768de603bf65e9aed0eea273db708608830f9b30e40d36cf96c2658947fb2",
                       "name": "Python-$PYTHON_VERSION.linux-armv6hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -982,7 +946,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "80d7da46d9de7727c1912630fe74a0e45c61b6fa58a1eaba08a772ac81bae8b9",
+                      "checksum": "2e19e1738ab22b314e06d2d2a00095956c7fe07e7223dcab7fa5a8d62d269ed2",
                       "name": "Python-$PYTHON_VERSION.linux-armv7hf-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -1014,7 +978,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "c811b37dfb62442ccf23f28ca81e5a48eb85b071a58ee69b278f25520196cb2e",
+                      "checksum": "d7b65ff75ecbba8b7db75f17bef16bec5154c6414a578c0361dcdc94337d8458",
                       "name": "Python-$PYTHON_VERSION.linux-amd64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -1046,7 +1010,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "f44f5617a7cd5593250bb8ad02044c37b433293343eacc84d78acae6490b7c53",
+                      "checksum": "24a00065335bf384ec1790e719b25ba27d75c9489d2387b2427df7390c9c284f",
                       "name": "Python-$PYTHON_VERSION.linux-aarch64-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }
@@ -1078,39 +1042,7 @@
                 {
                   "assets": {
                     "bin": {
-                      "checksum": "9cd9ed174d7508f08ce2ba72ba8062139cc94129942f0a393874a78f5cfb6f1a",
-                      "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
-                      "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
-                    }
-                  },
-                  "requires": [
-                    {
-                      "or": [
-                        { "type": "sw.os", "slug": "debian" , "version": "stretch" },
-                        { "type": "sw.os", "slug": "debian" , "version": "sid" },
-                        { "type": "sw.os", "slug": "debian" , "version": "buster" },
-                        { "type": "sw.os", "slug": "debian" , "version": "bullseye" },
-                        { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
-                        { "type": "sw.os", "slug": "ubuntu" , "version": "cosmic" },
-                        { "type": "sw.os", "slug": "ubuntu" , "version": "disco" },
-                        { "type": "sw.os", "slug": "ubuntu" , "version": "eoan" },
-                        { "type": "sw.os", "slug": "ubuntu" , "version": "focal" },
-                        { "type": "sw.os", "slug": "fedora" }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "requires": [
-                { "type": "arch.sw", "slug": "i386-nlp" }
-              ],
-              "variants": [
-                {
-                  "assets": {
-                    "bin": {
-                      "checksum": "9cd9ed174d7508f08ce2ba72ba8062139cc94129942f0a393874a78f5cfb6f1a",
+                      "checksum": "86c0a8a9ebdb9dc2b4c415a5d408c614372c2d1d0c2191350e2931705f76b15f",
                       "name": "Python-$PYTHON_VERSION.linux-i386-openssl1.1.tar.gz",
                       "url": "http://resin-packages.s3.amazonaws.com/python/v$PYTHON_VERSION/{{this.assets.bin.name}}"
                     }


### PR DESCRIPTION
This PR contains the following changes:
- Add Python v3.9.6 v3.8.11 v3.7.11 and v3.6.14
- Add latest dotnet releases
- Add node v16.6.2 v14.17.5 and v12.22.5
- Add golang v1.16.7 and v1.15.15