### PR TITLE
Few base images updates

### DIFF
--- a/contracts/sw.blob/qemu/contract.json
+++ b/contracts/sw.blob/qemu/contract.json
@@ -10,12 +10,12 @@
   },
   "variants": [
     {
-      "version": "5.2.0+balena4-arm",
+      "version": "6.0.0+balena1-arm",
       "assets": {
         "bin": {
           "name": "qemu-arm-static",
           "url": "file://./assets/qemu-arm-static",
-          "checksum": "8b410eabfb8417b6d8dcb7008fafa91c5f0496ab5db0b93a1b5b88cc7d86391e",
+          "checksum": "359c30fb422a18766642cdc634d575ca2d0b6d6d58bda0ec2e33b425c508194c",
           "main": "qemu-arm-static"
         }
       },
@@ -29,12 +29,12 @@
       ]
     },
     {
-      "version": "5.2.0+balena4-aarch64",
+      "version": "6.0.0+balena1-aarch64",
       "assets": {
         "bin": {
           "name": "qemu-aarch64-static",
           "url": "file://./assets/qemu-aarch64-static",
-          "checksum": "bc41a70415fc5066a9e8bae97c18cd8ffc3321b1cf83b147fa01e9da651cd581",
+          "checksum": "5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8",
           "main": "qemu-aarch64-static"
         }
       },

--- a/contracts/sw.os/alpine/contract.json
+++ b/contracts/sw.os/alpine/contract.json
@@ -4,8 +4,8 @@
   "version": "1",
   "data": { 
     "libc": "musl-libc",
-    "latest": "3.13",
-    "versionList": "`3.13 (latest)`, `3.14`, `3.11`, `3.12`, `edge`"
+    "latest": "3.14",
+    "versionList": "`3.14 (latest)`, `3.13`, `3.11`, `3.12`, `edge`"
   },
   "name": "Alpine Linux {{this.version}}",
   "requires": [

--- a/contracts/sw.stack/golang/contract.json
+++ b/contracts/sw.stack/golang/contract.json
@@ -4,8 +4,8 @@
   "name": "Go v{{this.version}}",
   "version": "1",
   "data": {
-    "latest": "1.16.7",
-    "versionList": "`1.16.6 (latest)`, `1.15.15`",
+    "latest": "1.17",
+    "versionList": "`1.17 (latest)`, `1.16.7`, `1.15.15`",
     "introduction": "Go (a.k.a., Golang) is a programming language first developed at Google. It is a statically-typed language with syntax loosely derived from C, but with additional features such as garbage collection, type safety, some dynamic-typing capabilities, additional built-in types (e.g., variable-length arrays and key-value maps), and a large standard library.",
     "logo": "https://raw.githubusercontent.com/docker-library/docs/01c12653951b2fe592c1f93a13b4e289ada0e3a1/golang/logo.png"
   },
@@ -27,6 +27,154 @@
     "manifest": "Go v{{this.version}}"
   },
   "variants": [
+    {
+      "version": "1.17",
+      "variants": [
+        {
+          "data": { "libc": "musl-libc" },
+          "requires": [
+            { "type": "sw.os", "slug": "alpine" }
+          ],
+          "variants": [
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "a38de816fa1871ff3584919ec092f8ce606d9f8e38865d19bbf5abb572d013df",
+                  "name": "go$GO_VERSION.linux-alpine-armv6hf.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
+                  
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "rpi" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "1e087d1dabe820b910d7d0e3ffd57d8653207b0bf50b46fe02f642f80b666c5e",
+                  "name": "go$GO_VERSION.linux-alpine-amd64.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "amd64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "c4cec524bb68366b7037f7c89dbd0183113707d163abf0bd9081df0eff89240c",
+                  "name": "go$GO_VERSION.linux-alpine-i386.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "i386" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "8883907ad9bef1875ade873ed3ffa7040bf3b0f3a285885ee9127a6390a158cc",
+                  "name": "go$GO_VERSION.linux-alpine-aarch64.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "aarch64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "a71cf0513b372b899f3c3919a92370e8736d46bb8addb2ac117c74c534f538e0",
+                  "name": "go$GO_VERSION.linux-alpine-armv7hf.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "armv7hf" }
+              ]
+            }
+          ]
+        },
+        {
+          "data": { "libc": "glibc" },
+          "requires": [
+            {
+              "or": [
+                { "type": "sw.os", "slug": "debian" },
+                { "type": "sw.os", "slug": "ubuntu" },
+                { "type": "sw.os", "slug": "fedora" }
+              ]
+            }
+          ],
+          "variants": [
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "ae89d33f4e4acc222bdb04331933d5ece4ae71039812f6ccd7493cb3e8ddfb4e",
+                  "name": "go$GO_VERSION.linux-armv6l.tar.gz",
+                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "rpi" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "31aaf7fa82a4a080e8f24e95faf1c97fea704e1064b7ea975d5ab10464018b29",
+                  "name": "go$GO_VERSION.linux-armv7hf.tar.gz",
+                  "url": "http://resin-packages.s3.amazonaws.com/golang/v$GO_VERSION/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "armv7hf" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d",
+                  "name": "go$GO_VERSION.linux-amd64.tar.gz",
+                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "amd64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "01a9af009ada22122d3fcb9816049c1d21842524b38ef5d5a0e2ee4b26d7c3e7",
+                  "name": "go$GO_VERSION.linux-arm64.tar.gz",
+                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "aarch64" }
+              ]
+            },
+            {
+              "assets": {
+                "bin": {
+                  "checksum": "c19e3227a6ac6329db91d1af77bbf239ccd760a259c16e6b9c932d527ff14848",
+                  "name": "go$GO_VERSION.linux-386.tar.gz",
+                  "url": "https://storage.googleapis.com/golang/{{this.assets.bin.name}}"
+                }
+              },
+              "requires": [
+                { "type": "arch.sw", "slug": "i386" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
     {
       "version": "1.16.7",
       "variants": [


### PR DESCRIPTION
This PR contains the following changes:
- Set Alpine Linux 3.14 as the latest tag.
- Update QEMU to v6.0.0-balena1.
- Add Golang v1.17.