### PR TITLE
hw.device-type: genericx86-64-ext: disable wlan/bluetooth

### DIFF
--- a/contracts/hw.device-type/genericx86-64-ext/contract.json
+++ b/contracts/hw.device-type/genericx86-64-ext/contract.json
@@ -15,8 +15,8 @@
     "hdmi": true,
     "led": false,
     "connectivity": {
-      "bluetooth": true,
-      "wifi": true
+      "bluetooth": false,
+      "wifi": false
     },
     "storage": {
       "internal": true


### PR DESCRIPTION
Disable wireless and bluetooth for genericx86-64-ext DT, as these are
not built-in and provided by default for this device type. This allows
core tests to pass in Leviathan, as it's not assumed that these devices
are present.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>