### PR TITLE
Update dotnet partials

### DIFF
--- a/contracts/sw.stack+sw.os+hw.device-type/dotnet-aspnet-3.x.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/dotnet-aspnet-3.x.tpl
@@ -3,7 +3,7 @@ ENV DOTNET_VERSION {{sw.stack.assets.runtime.fullVersion}}
 
 RUN curl -SL --output dotnet.tar.gz "{{sw.stack.assets.runtime.bin.url}}" \
     && dotnet_sha512='{{sw.stack.assets.runtime.bin.checksum}}' \
-    && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \

--- a/contracts/sw.stack+sw.os+hw.device-type/dotnet-runtime.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/dotnet-runtime.tpl
@@ -3,7 +3,7 @@ ENV DOTNET_VERSION {{sw.stack.data.fullVersion}}
 
 RUN curl -SL --output dotnet.tar.gz "{{sw.stack.assets.bin.url}}" \
     && dotnet_sha512='{{sw.stack.assets.bin.checksum}}' \
-    && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \

--- a/contracts/sw.stack+sw.os+hw.device-type/dotnet-sdk.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/dotnet-sdk.tpl
@@ -3,7 +3,7 @@ ENV DOTNET_SDK_VERSION {{sw.stack.data.fullVersion}}
 
 RUN curl -SL --output dotnet.tar.gz "{{sw.stack.assets.bin.url}}" \
     && dotnet_sha512='{{sw.stack.assets.bin.checksum}}' \
-    && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \


### PR DESCRIPTION
Use two spaces when verifying binary checksum

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>