### PR TITLE
hw.device-type: Update sources.list to L4T 32.6.1

### DIFF
--- a/contracts/sw.os+hw.device-type/debian+jetson-nano-2gb-devkit/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-nano-2gb-devkit/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-nano-emmc/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-nano-emmc/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-nano/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-nano/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-tx2/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-tx2/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit-emmc/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit-emmc/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-xavier-nx-devkit/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-nano-2gb-devkit/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-nano-2gb-devkit/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-nano-emmc/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-nano-emmc/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-nano/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-nano/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t210 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-tx2/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-tx2/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t186 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit-emmc/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit-emmc/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier-nx-devkit/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall


### PR DESCRIPTION
This is part one which updates the base images for
the following devices, which have the kernel updated
to L4T 32.6.1 in the OS image:
- Jetson Nano 2GB
- Jetson Nano eMMC
- Jetson Nano SD-CARD
- Jetson Xavier NX
- Jetson TX2 NX

The following devices will have the base
images updated in a subsequent commit, after
new OS images are released for them:
- Jetson TX2
- Jetson Xavier AGX

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>