### PR TITLE
hw.device-type: Update sources.list to L4T 32.6.1

### DIFF
--- a/contracts/sw.os+hw.device-type/debian+jetson-xavier/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-xavier/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-xavier/distro-config.tpl
@@ -1,4 +1,4 @@
-RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
-	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.5 main" >>  /etc/apt/sources.list.d/nvidia.list \
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t194 r32.6 main" >>  /etc/apt/sources.list.d/nvidia.list \
 	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
 	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall


### PR DESCRIPTION
This is part two of the update, which sets the base images to
l4t 32.6 for the Jetson Xavier AGX

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>