### PR TITLE
patch: Update RPi0 2 W's name

### DIFF
--- a/contracts/hw.device-type/raspberrypi0-2w-64/contract.json
+++ b/contracts/hw.device-type/raspberrypi0-2w-64/contract.json
@@ -3,7 +3,7 @@
   "version": "1",
   "type": "hw.device-type",
   "aliases": [],
-  "name": "Raspberry Pi Zero 2 Wifi (64bit)",
+  "name": "Raspberry Pi Zero 2 W (64bit)",
   "assets": {
     "logo": {
       "url": "./raspberrypi0-2w-64.svg",


### PR DESCRIPTION
This board's correct name as per its nomenclature is [Raspberry Pi Zero 2 W](https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/)

Context: https://github.com/balena-io/docs/issues/2018#issuecomment-1040788307

Fixing it here to fix it everywhere