### PR TITLE
hw.device-type: Correct NanoPi R2C device contract

### DIFF
--- a/contracts/hw.device-type/nanopi-r2c/contract.json
+++ b/contracts/hw.device-type/nanopi-r2c/contract.json
@@ -16,7 +16,7 @@
     "led": true,
     "connectivity": {
       "bluetooth": false,
-      "wifi": true
+      "wifi": false
     },
     "storage": {
       "internal": false


### PR DESCRIPTION
The device does not have any WiFi chipset so let's correct that

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>