### PR TITLE
Add sw.os and sw.os-image contracts

### DIFF
--- a/contracts/sw.os-image/balenaos/contract.json
+++ b/contracts/sw.os-image/balenaos/contract.json
@@ -1,0 +1,6 @@
+{
+  "slug": "balena-image",
+  "name": "Balena OS raw image",
+  "type": "sw.os-image",
+  "version": "1"
+}

--- a/contracts/sw.os/balenaos/contract.json
+++ b/contracts/sw.os/balenaos/contract.json
@@ -1,0 +1,19 @@
+{
+  "slug": "balena-os",
+  "name": "Balena OS",
+  "type": "sw.os",
+  "version": "2",
+  "data": { "libc": "glibc" },
+  "requires": [
+    {
+      "or": [
+        { "type": "arch.sw", "slug": "armv7hf" },
+        { "type": "arch.sw", "slug": "rpi" },
+        { "type": "arch.sw", "slug": "aarch64" },
+        { "type": "arch.sw", "slug": "i386" },
+        { "type": "arch.sw", "slug": "amd64" }
+      ]
+    },
+    { "type": "sw.os-image", "slug": "balena-image" }
+  ]
+}


### PR DESCRIPTION
These will be used by the OS builders when deploying OS releases.