### PR TITLE
patch: Assume hdmi false for generic-aarch64 devices

### DIFF
--- a/contracts/hw.device-type/generic-aarch64/contract.json
+++ b/contracts/hw.device-type/generic-aarch64/contract.json
@@ -12,7 +12,7 @@
   },
   "data": {
     "arch": "aarch64",
-    "hdmi": true,
+    "hdmi": false,
     "led": false,
     "connectivity": {
       "bluetooth": false,


### PR DESCRIPTION
Resolves: https://github.com/balena-os/meta-balena/issues/2714