### PR TITLE
hw.device-type: Set LED to false for rockpi-4b

### DIFF
--- a/contracts/hw.device-type/rockpi-4b-rk3399/contract.json
+++ b/contracts/hw.device-type/rockpi-4b-rk3399/contract.json
@@ -13,7 +13,7 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
-    "led": true,
+    "led": false,
     "connectivity": {
       "bluetooth": true,
       "wifi": true


### PR DESCRIPTION
LED is not supported for this DT in the device
repository, let's set it to false here so that
the tests are aware of this being unsupported.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>