### PR TITLE
hw.device-type: Remove led for RockPro64

### DIFF
--- a/contracts/hw.device-type/rockpro64/contract.json
+++ b/contracts/hw.device-type/rockpro64/contract.json
@@ -13,7 +13,7 @@
   "data": {
     "arch": "aarch64",
     "hdmi": true,
-    "led": true,
+    "led": false,
     "connectivity": {
       "bluetooth": false,
       "wifi": false


### PR DESCRIPTION
This DT does not set a led in the device
repository, let's remove this option
from here for testbot.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>