### PR TITLE
Fix incorrect partials in device type contracts

### DIFF
--- a/contracts/hw.device-type/generic-aarch64/contract.json
+++ b/contracts/hw.device-type/generic-aarch64/contract.json
@@ -22,15 +22,12 @@
       "internal": false
     },
     "media": {
-      "defaultBoot": "image"
+      "defaultBoot": "sdcard",
+      "altBoot": ["usb_mass_storage", "network"]
     },
     "is_private": false
   },
   "partials": {
-    "instructions": [
-      "Download/pull the following docker image on the target machine: <code>{{ dockerImage }}</code> .",
-      "Download the configuration file and deploy it on target.",
-      "Run the resinOS container using <a href=\"https://github.com/resin-os/resinos-in-container\">resinos-in-container</a>. This tool/script will reference the image and the configuration file (downloaded above) as command line arguments. Example: <code>./resinos-in-container.sh --config ./config.json --image {{ dockerImage }}</code>. Tweak the <code>--config</code> argument based on the filename set for the downloaded configuration file."
-    ]
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/generic-armv7ahf/contract.json
+++ b/contracts/hw.device-type/generic-armv7ahf/contract.json
@@ -22,8 +22,12 @@
       "internal": false
     },
     "media": {
-      "defaultBoot": "sdcard"
+      "defaultBoot": "sdcard",
+      "altBoot": ["usb_mass_storage", "network"]
     },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/generic/contract.json
+++ b/contracts/hw.device-type/generic/contract.json
@@ -22,8 +22,12 @@
       "internal": false
     },
     "media": {
-      "defaultBoot": "sdcard"
+      "defaultBoot": "sdcard",
+      "altBoot": ["usb_mass_storage", "network"]
     },
     "is_private": false
+  },
+  "partials": {
+    "bootDevice": ["Connect power to the {{name}}"]
   }
 }

--- a/contracts/hw.device-type/iot-gate-imx8/contract.json
+++ b/contracts/hw.device-type/iot-gate-imx8/contract.json
@@ -23,7 +23,7 @@
     },
     "media": {
       "defaultBoot": "internal",
-      "altBoot": ["sdcard"]
+      "altBoot": ["usb_mass_storage"]
     },
     "is_private": false
   },


### PR DESCRIPTION
While testing new contract based instruction generation, I found a couple incorrect partials in the contacts. This resolves these issues.

Change-type: patch
Signed-off-by: Micah Halter <micah@balena.io>