### PR TITLE
hw.device-type: Various fixes

### DIFF
--- a/contracts/hw.device-type/jetson-tx2-nx-devkit/contract.json
+++ b/contracts/hw.device-type/jetson-tx2-nx-devkit/contract.json
@@ -23,7 +23,7 @@
     },
     "flashProtocol": "jetsonFlash",
     "media": {
-      "defaultBoot": "sdcard"
+      "defaultBoot": "internal"
     },
     "is_private": false
   },

--- a/contracts/hw.device-type/jn30b-nano/contract.json
+++ b/contracts/hw.device-type/jn30b-nano/contract.json
@@ -23,7 +23,7 @@
     },
     "flashProtocol": "jetsonFlash",
     "media": {
-      "defaultBoot": "sdcard"
+      "defaultBoot": "internal"
     },
     "is_private": false
   },

--- a/contracts/hw.device-type/owa5x/contract.json
+++ b/contracts/hw.device-type/owa5x/contract.json
@@ -30,7 +30,7 @@
   "partials": {
     "bootDeviceExternal": [
       "Erase internal NAND content",
-      "Insert an SD card with a boootable image"
+      "Insert an SD card with a bootable image"
     ],
     "flashIndicator": ["all LEDs are off"],
     "bootDevice": ["Remove and re-connect power to the {{name}}"]

--- a/contracts/hw.device-type/radxa-cm3-rpicm4-ioboard/contract.json
+++ b/contracts/hw.device-type/radxa-cm3-rpicm4-ioboard/contract.json
@@ -21,7 +21,7 @@
     "storage": {
       "internal": true
     },
-    "flashProtocol": "RPIBOOT",
+    "flashProtocol": "radxaFlash",
     "media": {
       "defaultBoot": "internal"
     },

--- a/contracts/hw.device-type/radxa-cm3-rpicm4-ioboard/contract.json
+++ b/contracts/hw.device-type/radxa-cm3-rpicm4-ioboard/contract.json
@@ -28,10 +28,11 @@
     "is_private": false
   },
   "partials": {
-    "connectDevice": [
-      "Connect the {{name}} to your computer with a USB-C cable"
-    ],
-    "disconnectDevice": ["Unplug the USB-C cable from the {{name}}."],
-    "bootDevice": ["Remove and re-connect power to the {{name}}"]
+    "instructions": [
+     "Use the <a href=https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Boot_the_board_to_maskrom_mode>maskrom mode</a> instructions supplied by the vendor and ensure the device's MicroUSB port is used for provisioning.",
+     "Install on your PC the <a href=https://wiki.radxa.com/Rock3/install/rockchip-flash-tools>rockchip flash tools</a> required for flashing.",
+     "Clear eMMC and set it in UMS mode. Make sure to use <a href=https://dl.radxa.com/rock3/images/loader/rk356x_spl_loader_ddr1056_v1.06.110.bin>this loader</a> when following the <a href=https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Begin_Installation_USB_-.3E_eMMC>USB provisioning instructions</a>.",
+     "Once the OS has been written to the eMMC you need to repower your board. Make sure you take into account the <a href=https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Power_on>power on instructions</a>."
+    ]
   }
 }

--- a/contracts/hw.device-type/radxa-zero/contract.json
+++ b/contracts/hw.device-type/radxa-zero/contract.json
@@ -28,10 +28,12 @@
     "is_private": false
   },
   "partials": {
-    "connectDevice": [
-      "Connect the {{name}} to your computer with a USB-C cable"
-    ],
-    "disconnectDevice": ["Unplug the USB-C cable from the {{name}}."],
-    "bootDevice": ["Remove and re-connect power to the {{name}}"]
+    "instructions": [
+        "Use the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Enable_maskrom>maskrom mode</a> instructions provided by the vendor and make sure the board's USB2 port is used for provisioning.",
+        "Install on your PC the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Install_required_tools>tools</a> required for flashing.",
+        "Clear eMMC and set it in UMS mode. Make sure to use <a href=https://dl.radxa.com/zero/images/loader/radxa-zero-erase-emmc.bin>this loader</a> when following the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Side_loading_binaries>sideloading instructions</a>.",
+        "Write the OS to the internal MMC storage device. We recommend using <a href=http://www.etcher.io/>Etcher</a>.",
+        "Once the OS has been written to the eMMC you need to repower your board."
+    ]
   }
 }

--- a/contracts/hw.device-type/radxa-zero/contract.json
+++ b/contracts/hw.device-type/radxa-zero/contract.json
@@ -21,7 +21,7 @@
     "storage": {
       "internal": true
     },
-    "flashProtocol": "RPIBOOT",
+    "flashProtocol": "radxaFlash",
     "media": {
       "defaultBoot": "internal"
     },

--- a/contracts/hw.device-type/raspberrypicm4-ioboard/contract.json
+++ b/contracts/hw.device-type/raspberrypicm4-ioboard/contract.json
@@ -19,12 +19,12 @@
       "wifi": true
     },
     "storage": {
-      "internal": false
+      "internal": true
     },
     "flashProtocol": "RPIBOOT",
     "media": {
       "defaultBoot": "internal",
-      "altBoot": ["sdcard"]
+      "altBoot": ["sdcard", "usb_mass_storage", "nvme"]
     },
     "is_private": false
   },


### PR DESCRIPTION
- The Jetson TX2 NX has an eMMC and no SD-CARD slot
- The JN30B Nano uses the eMMC module and not the SD-CARD one
- The Radxa CM3 on RPI CM4 IOBoard as well as the Radxa zero use rockchip software tools in order to put the eMMC in mass-storage mode
- The CM4 module comes in two flavors: one with eMMC and the Lite version which uses the carrier board sd-card slot to load the image. Both use the same balenaOS image. I switched the storage to internal for this DT because it *may* have one, but this solely depends on the actual module. Another consideration is that this DT can also boot from a USB stick or a NVME drive connected to the mPCIE port.

Change-type: patch