### PR TITLE
node: do not set unsafe-perm with npm 9 and newer

### DIFF
--- a/contracts/sw.stack+sw.os+hw.device-type/node+alpine/build.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/node+alpine/build.tpl
@@ -24,5 +24,5 @@ RUN for key in \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
 	&& rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
+	&& ( [ "$(npm --version | cut -d '.' -f 1)" -gt 8 ] || npm config set unsafe-perm true -g --unsafe-perm ) \
 	&& rm -rf /tmp/*

--- a/contracts/sw.stack+sw.os+hw.device-type/node+alpine/run.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/node+alpine/run.tpl
@@ -27,5 +27,5 @@ RUN buildDeps='curl' \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
 	&& rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
+	&& ( [ "$(npm --version | cut -d '.' -f 1)" -gt 8 ] || npm config set unsafe-perm true -g --unsafe-perm ) \
 	&& rm -rf /tmp/*

--- a/contracts/sw.stack+sw.os+hw.device-type/node+debian/build.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/node+debian/build.tpl
@@ -20,5 +20,5 @@ RUN for key in \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
 	&& rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
+	&& ( [ "$(npm --version | cut -d '.' -f 1)" -gt 8 ] || npm config set unsafe-perm true -g --unsafe-perm ) \
 	&& rm -rf /tmp/*

--- a/contracts/sw.stack+sw.os+hw.device-type/node+debian/run.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/node+debian/run.tpl
@@ -24,5 +24,5 @@ RUN buildDeps='curl libatomic1' \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
 	&& rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
+	&& ( [ "$(npm --version | cut -d '.' -f 1)" -gt 8 ] || npm config set unsafe-perm true -g --unsafe-perm ) \
 	&& rm -rf /tmp/*

--- a/contracts/sw.stack+sw.os+hw.device-type/node+fedora/build.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/node+fedora/build.tpl
@@ -20,5 +20,5 @@ RUN for key in \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
 	&& rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
+	&& ( [ "$(npm --version | cut -d '.' -f 1)" -gt 8 ] || npm config set unsafe-perm true -g --unsafe-perm ) \
 	&& rm -rf /tmp/*

--- a/contracts/sw.stack+sw.os+hw.device-type/node+fedora/run.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/node+fedora/run.tpl
@@ -20,5 +20,5 @@ RUN for key in \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
 	&& rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
+	&& ( [ "$(npm --version | cut -d '.' -f 1)" -gt 8 ] || npm config set unsafe-perm true -g --unsafe-perm ) \
 	&& rm -rf /tmp/*

--- a/contracts/sw.stack+sw.os+hw.device-type/node+ubuntu/build.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/node+ubuntu/build.tpl
@@ -20,5 +20,5 @@ RUN for key in \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
 	&& rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
+	&& ( [ "$(npm --version | cut -d '.' -f 1)" -gt 8 ] || npm config set unsafe-perm true -g --unsafe-perm ) \
 	&& rm -rf /tmp/*

--- a/contracts/sw.stack+sw.os+hw.device-type/node+ubuntu/run.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/node+ubuntu/run.tpl
@@ -24,5 +24,5 @@ RUN buildDeps='curl libatomic1' \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
 	&& ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
 	&& rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-	&& npm config set unsafe-perm true -g --unsafe-perm \
+	&& ( [ "$(npm --version | cut -d '.' -f 1)" -gt 8 ] || npm config set unsafe-perm true -g --unsafe-perm ) \
 	&& rm -rf /tmp/*


### PR DESCRIPTION
The `unsafe-perm` config option has been dropped in `npm` 9, trying to set it ends with an error and therefore fails the build. With this patch the build script parses the major version from `npm --version` and only sets `unsafe-perm` on `npm` 8 and older.