### PR TITLE
Fix LED and HDMI support for ISG-503

### DIFF
--- a/contracts/hw.device-type/isg-503/contract.json
+++ b/contracts/hw.device-type/isg-503/contract.json
@@ -13,7 +13,7 @@
   "data": {
     "arch": "aarch64",
     "hdmi": false,
-    "led": true,
+    "led": false,
     "connectivity": {
       "bluetooth": false,
       "wifi": false


### PR DESCRIPTION
The LED support was incorrectly changed in https://github.com/balena-io/contracts/commit/4bb6eb1f732957e605f00e47b068199f14ff1765 Let's switch it back to unsupported. 

Change-type: patch