### PR TITLE
hw/device-type: Update contract.json for iot-gate-imx8

### DIFF
--- a/contracts/hw.device-type/iot-gate-imx8/contract.json
+++ b/contracts/hw.device-type/iot-gate-imx8/contract.json
@@ -13,7 +13,7 @@
   "data": {
     "arch": "aarch64",
     "hdmi": false,
-    "led": true,
+    "led": false,
     "connectivity": {
       "bluetooth": true,
       "wifi": true


### PR DESCRIPTION
To specify that the iot-gate-imx8 doesn't have an identification LED

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>