### PR TITLE
sw.os+hw.device-type: Add ubuntu and debian distro configs for Orin Nano

### DIFF
--- a/contracts/sw.os+hw.device-type/debian+jetson-orin-nano-devkit-nvme/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/debian+jetson-orin-nano-devkit-nvme/distro-config.tpl
@@ -1,0 +1,4 @@
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r35.3 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t234 r35.3 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall

--- a/contracts/sw.os+hw.device-type/ubuntu+jetson-orin-nano-devkit-nvme/distro-config.tpl
+++ b/contracts/sw.os+hw.device-type/ubuntu+jetson-orin-nano-devkit-nvme/distro-config.tpl
@@ -1,0 +1,4 @@
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r35.3 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& echo "deb https://repo.download.nvidia.com/jetson/t234 r35.3 main" >>  /etc/apt/sources.list.d/nvidia.list \
+	&& apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc \
+	&& mkdir -p /opt/nvidia/l4t-packages/ && touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall


### PR DESCRIPTION
Connects-to: https://github.com/balena-os/balena-jetson-orin/pull/212

Tested 35.3 on Orin Nano Devkit NVME:

```
cp clock ../../bin/aarch64/linux/release
CUDA Clock sample
GPU Device 0: "Ampere" with compute capability 8.7

Average clocks/block = 1965.765625
```