### PR TITLE
Remove OpenJDK v7 as it has been removed from alpine edge

### DIFF
--- a/contracts/sw.stack/openjdk/contract.json
+++ b/contracts/sw.stack/openjdk/contract.json
@@ -25,18 +25,6 @@
   ],
   "variants": [
     {
-      "version": "7-jdk",
-      "requires": [
-        { "type": "sw.os", "slug": "alpine" }
-      ]
-    },
-    {
-      "version": "7-jre",
-      "requires": [
-        { "type": "sw.os", "slug": "alpine" }
-      ]
-    },
-    {
       "version": "8-jdk",
       "requires": [
         {


### PR DESCRIPTION
Change-type: patch