### PR TITLE
raspberrypi5: Explicitly flag as public for the switch to apply

### DIFF
--- a/contracts/hw.device-type/raspberrypi5/contract.json
+++ b/contracts/hw.device-type/raspberrypi5/contract.json
@@ -24,7 +24,8 @@
     "media": {
       "defaultBoot": "sdcard",
       "altBoot": ["usb_mass_storage", "network"]
-    }
+    },
+    "is_private": false
   },
   "partials": {
     "bootDevice": ["Connect power to the {{name}}"]


### PR DESCRIPTION
As the device was previously private, the `is_private` needs to be explicitly set to false for the device type to become public.

Change-type: patch