### PR TITLE
raspberrypi5: remove reference to 64bits in display name

### DIFF
--- a/contracts/hw.device-type/raspberrypi5/contract.json
+++ b/contracts/hw.device-type/raspberrypi5/contract.json
@@ -3,7 +3,7 @@
   "version": "1",
   "type": "hw.device-type",
   "aliases": [],
-  "name": "Raspberry Pi 5 (using 64bit OS)",
+  "name": "Raspberry Pi 5",
   "assets": {
     "logo": {
       "url": "./raspberrypi5.svg",


### PR DESCRIPTION
There won't be a 32bits OS for this device type.

Change-type: patch