### PR TITLE
lcbzu9: boot from internal storage

### DIFF
--- a/contracts/hw.device-type/lcbzu9/contract.json
+++ b/contracts/hw.device-type/lcbzu9/contract.json
@@ -19,10 +19,11 @@
       "wifi": true
     },
     "storage": {
-      "internal": false
+      "internal": true
     },
     "media": {
-      "defaultBoot": "sdcard"
+      "defaultBoot": "internal",
+      "altBoot": ["sdcard"]
     },
     "is_private": false
   },


### PR DESCRIPTION
Make flasher image available for download to boot lcbzu9 from eMMC

Changelog-entry: patch