### PR TITLE
patch: Remove Tinker Board Wiki link going 404

### DIFF
--- a/contracts/hw.device-type/asus-tinker-board-s/contract.json
+++ b/contracts/hw.device-type/asus-tinker-board-s/contract.json
@@ -30,12 +30,12 @@
   },
   "partials": {
     "bootDeviceExternal": [
-      "Make sure that the jumper between the 5V power supply and the HDMI connect is in the MASKROM mode as illustrated on the <a href=\"https://tinkerboarding.co.uk/wiki/index.php/Setup\">Tinker Board Wiki</a>.",
+      "Make sure that the jumper between the 5V power supply and the HDMI connect is in the MASKROM mode.",
       "Connect power to the {{name}}."
     ],
     "flashIndicator": ["all LEDs are off"],
     "bootDevice": [
-      "Make sure that the jumper between the 5V power supply and the HDMI connect is in the parking (no function) mode as illustrated on the <a href=\"https://tinkerboarding.co.uk/wiki/index.php/Setup\">Tinker Board Wiki</a>.",
+      "Make sure that the jumper between the 5V power supply and the HDMI connect is in the parking (no function) mode.",
       "Remove and re-connect power to the {{name}}."
     ]
   }


### PR DESCRIPTION
Folks, the link for the Tinker Board wiki instructions is dead which results in the Getting Started instructions having a dead link. Can you suggest a replacement for the link in the current documentation please or I would like to remove it/change the wording a bit for users to make sense. Let me know what you recommend? @acostach @floion 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
