### PR TITLE
hw.device-type: Fix device type is_private flag for imx8mp-var-dart

### DIFF
--- a/contracts/hw.device-type/imx8mp-var-dart/contract.json
+++ b/contracts/hw.device-type/imx8mp-var-dart/contract.json
@@ -25,7 +25,7 @@
       "defaultBoot": "internal",
       "altBoot": ["sdcard"]
     },
-    "is_private": true
+    "is_private": false
   },
   "partials": {
     "bootDeviceExternal": [


### PR DESCRIPTION
This was added by mistake as private when it is supposed to be a public dt.

Change-type: patch