### PR TITLE
hw.device-type: Fix hyperlinks in provisioning instructions

### DIFF
--- a/contracts/hw.device-type/iot-gate-imx8plus-d1d8/contract.json
+++ b/contracts/hw.device-type/iot-gate-imx8plus-d1d8/contract.json
@@ -31,7 +31,7 @@
     "instructions": [
       "Unpack the balenaOS image you downloaded from balena-cloud.",
       "Make sure the device is not powered and connect the PROG port to your PC using a micro USB cable.",
-      "From a Linux-based host, use the <a href=https://github.com/balena-os/iot-gate-imx8plus-flashtools>IOT-GATE-iMX8PLUS flashing tools</a> to write balenaOS on your device.",
+      "From a Linux-based host, use the <a href=\"https://github.com/balena-os/iot-gate-imx8plus-flashtools\">IOT-GATE-iMX8PLUS flashing tools</a> to write balenaOS on your device.",
       "After flashing is completed, disconnect the micro USB cable from the PROG port, power off the device and then power it back on."
     ]
   }

--- a/contracts/hw.device-type/iot-gate-imx8plus/contract.json
+++ b/contracts/hw.device-type/iot-gate-imx8plus/contract.json
@@ -31,7 +31,7 @@
     "instructions": [
       "Unpack the balenaOS image you downloaded from balena-cloud.",
       "Make sure the device is not powered and connect the PROG port to your PC using a micro USB cable.",
-      "From a Linux-based host, use the <a href=https://github.com/balena-os/iot-gate-imx8plus-flashtools>IOT-GATE-iMX8PLUS flashing tools</a> to write balenaOS on your device.",
+      "From a Linux-based host, use the <a href=\"https://github.com/balena-os/iot-gate-imx8plus-flashtools\">IOT-GATE-iMX8PLUS flashing tools</a> to write balenaOS on your device.",
       "After flashing is completed, disconnect the micro USB cable from the PROG port, power off the device and then power it back on."
     ]
   }

--- a/contracts/hw.device-type/radxa-cm3-rpicm4-ioboard/contract.json
+++ b/contracts/hw.device-type/radxa-cm3-rpicm4-ioboard/contract.json
@@ -29,10 +29,10 @@
   },
   "partials": {
     "instructions": [
-     "Use the <a href=https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Boot_the_board_to_maskrom_mode>maskrom mode</a> instructions supplied by the vendor and ensure the device's MicroUSB port is used for provisioning.",
-     "Install on your PC the <a href=https://wiki.radxa.com/Rock3/install/rockchip-flash-tools>rockchip flash tools</a> required for flashing.",
-     "Clear eMMC and set it in UMS mode. Make sure to use <a href=https://dl.radxa.com/rock3/images/loader/rk356x_spl_loader_ddr1056_v1.06.110.bin>this loader</a> when following the <a href=https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Begin_Installation_USB_-.3E_eMMC>USB provisioning instructions</a>.",
-     "Once the OS has been written to the eMMC you need to repower your board. Make sure you take into account the <a href=https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Power_on>power on instructions</a>."
+     "Use the <a href=\"https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Boot_the_board_to_maskrom_mode\">maskrom mode</a> instructions supplied by the vendor and ensure the device's MicroUSB port is used for provisioning.",
+     "Install on your PC the <a href=\"https://wiki.radxa.com/Rock3/install/rockchip-flash-tools\">rockchip flash tools</a> required for flashing.",
+     "Clear eMMC and set it in UMS mode. Make sure to use <a href=\"https://dl.radxa.com/rock3/images/loader/rk356x_spl_loader_ddr1056_v1.06.110.bin\">this loader</a> when following the <a href=\"https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Begin_Installation_USB_-.3E_eMMC\">USB provisioning instructions</a>.",
+     "Once the OS has been written to the eMMC you need to repower your board. Make sure you take into account the <a href=\"https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Power_on\">power on instructions</a>."
     ]
   }
 }

--- a/contracts/hw.device-type/radxa-zero/contract.json
+++ b/contracts/hw.device-type/radxa-zero/contract.json
@@ -29,10 +29,10 @@
   },
   "partials": {
     "instructions": [
-        "Use the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Enable_maskrom>maskrom mode</a> instructions provided by the vendor and make sure the board's USB2 port is used for provisioning.",
+        "Use the <a href=\"https://wiki.radxa.com/Zero/dev/maskrom#Enable_maskrom\">maskrom mode</a> instructions provided by the vendor and make sure the board's USB2 port is used for provisioning.",
         "Install on your PC the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Install_required_tools>tools</a> required for flashing.",
         "Clear eMMC and set it in UMS mode. Make sure to use <a href=https://dl.radxa.com/zero/images/loader/radxa-zero-erase-emmc.bin>this loader</a> when following the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Side_loading_binaries>sideloading instructions</a>.",
-        "Write the OS to the internal eMMC storage device. We recommend using <a href=http://www.etcher.io/>Etcher</a>.",
+        "Write the OS to the internal eMMC storage device. We recommend using <a href=\"http://www.etcher.io\">Etcher</a>.",
         "Once the OS has been written to the eMMC you need to repower your board."
     ]
   }


### PR DESCRIPTION
If hyperlinks are unquoted, a target=blank is added and entire link is broken in the dashboard. This doesn't happen for devices which use quoted links, like for example the CM4.

Change-type: patch