### PR TITLE
hw.device-type: Update provisioning instructions for AGX Orin 64GB

### DIFF
--- a/contracts/hw.device-type/jetson-agx-orin-devkit-64gb/contract.json
+++ b/contracts/hw.device-type/jetson-agx-orin-devkit-64gb/contract.json
@@ -29,10 +29,9 @@
   },
   "partials": {
     "bootDeviceExternal": [
-        "Insert a NVME drive in the Devkit and put the device in <a href=\"https://github.com/balena-os/jetson-flash#recovery-mode\">force recovery</a> mode.",
-        "Please note that both the NVME and the eMMC will be erased during the provisioning process.",
-        "Connect the USB-C port of the Devkit to the Host PC.",
-        "RCM boot the balenaOS kernel following the <a href=\"https://github.com/balena-os/jetson-flash#agx-orin-devkit-64gb-flashing\">AGX Orin Devkit 64GB flashing steps</a>."
+        "Put the device in <a href=\"https://github.com/balena-os/jetson-flash#recovery-mode\">force recovery</a> mode.",
+        "Connect the USB-C data port of the Devkit to the Host PC.",
+        "Boot the device from the inserted USB Key by following the <a href=\"https://github.com/balena-os/jetson-flash#agx-orin-devkit-64gb-flashing\">AGX Orin Devkit 64GB flashing steps</a>."
     ],
     "flashIndicator": ["power LED is off"],
     "bootDevice": ["Power up the {{name}}"]


### PR DESCRIPTION
The AGX Orin 64GB should be provisioned on the eMMC by default as per the internal thread https://balena.zulipchat.com/#narrow/stream/346009-aspect.2Fcustomer-success/topic/Get.20feedback.20on.20draft.20balenaOS.20with.20L4T.2036.2E3.20for.20Jetson.20Orin/near/455889690

We thus update the provisioning instructions accordingly

Change-type: patch