### PR TITLE
iotdin-imx8p: Update the devices contract

### DIFF
--- a/contracts/hw.device-type/iotdin-imx8p-d1d8/contract.json
+++ b/contracts/hw.device-type/iotdin-imx8p-d1d8/contract.json
@@ -15,8 +15,8 @@
     "hdmi": false,
     "led": false,
     "connectivity": {
-      "bluetooth": true,
-      "wifi": true
+      "bluetooth": false,
+      "wifi": false
     },
     "storage": {
       "internal": true

--- a/contracts/hw.device-type/iotdin-imx8p/contract.json
+++ b/contracts/hw.device-type/iotdin-imx8p/contract.json
@@ -15,8 +15,8 @@
     "hdmi": false,
     "led": false,
     "connectivity": {
-      "bluetooth": true,
-      "wifi": true
+      "bluetooth": false,
+      "wifi": false
     },
     "storage": {
       "internal": true


### PR DESCRIPTION
Disable bluetooth and wifi in the devices contracts files. Reason: the CompuLab Autokit came without an IFM-WB i/o module.