### PR TITLE
hw.device-type: Switch to using markdown for links

### DIFF
--- a/contracts/hw.device-type/forecr-dsb-ornx-lan-orin-nx-16gb/contract.json
+++ b/contracts/hw.device-type/forecr-dsb-ornx-lan-orin-nx-16gb/contract.json
@@ -29,8 +29,8 @@
   },
   "partials": {
     "instructions": [
-        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the <a href=\"https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin\">firmware version</a> before proceeding.",
-        "For balenaOS versions older than v6.1.16, please refer to the <a href=\"https://github.com/balena-os/jetson-flash?tab=readme-ov-file\">{{name}} legacy flashing</a> guide."
+        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the [firmware version](https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin) before proceeding.",
+        "For balenaOS versions older than v6.1.16, please refer to the [{{name}} legacy flashing](https://github.com/balena-os/jetson-flash?tab=readme-ov-file) guide."
     ],
     "bootDeviceExternal": [
         "Insert a NVME drive in the board and power up the {{name}}."

--- a/contracts/hw.device-type/forecr-dsb-ornx-orin-nano-8gb/contract.json
+++ b/contracts/hw.device-type/forecr-dsb-ornx-orin-nano-8gb/contract.json
@@ -29,8 +29,8 @@
   },
   "partials": {
     "instructions": [
-        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the <a href=\"https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin\">firmware version</a> before proceeding.",
-        "For balenaOS versions older than v6.1.16, please refer to the <a href=\"https://github.com/balena-os/jetson-flash?tab=readme-ov-file\">{{name}} legacy flashing</a> guide."
+        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the [firmware version](https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin) before proceeding.",
+        "For balenaOS versions older than v6.1.16, please refer to the [{{name}} legacy flashing](https://github.com/balena-os/jetson-flash?tab=readme-ov-file) guide."
     ],
     "bootDeviceExternal": [
         "Insert a NVME drive in the board and power up the {{name}}."

--- a/contracts/hw.device-type/intel-edison/contract.json
+++ b/contracts/hw.device-type/intel-edison/contract.json
@@ -39,7 +39,7 @@
     },
     "MacOS": {
       "flashDependencies": [
-        "You need <a href='https://www.macports.org/'>MacPorts</a> installed on your system.",
+        "You need [MacPorts](https://www.macports.org/) installed on your system.",
         "Run the following to install <code>dfu-utils</code>, <code>usbutils</code>, and <code>coreutils</code>: <code>sudo port install dfu-util usbutils coreutils && sudo port activate dfu-util</code>"
       ],
       "flashInstructions": [
@@ -49,7 +49,7 @@
     },
     "Windows": {
       "flashDependencies": [
-        "Install Windows drives for Edison from <a href='https://downloadmirror.intel.com/26993/eng/IntelEdisonDriverSetup1.2.1.exe'>here</a>"
+        "Install Windows drives for Edison from [here](https://downloadmirror.intel.com/26993/eng/IntelEdisonDriverSetup1.2.1.exe)."
       ],
       "flashInstructions": [
         "Open a terminal with administrative privileges and execute the following from the unzipped directory: <code>flashall.bat</code>"

--- a/contracts/hw.device-type/iot-gate-imx8plus-d1d8/contract.json
+++ b/contracts/hw.device-type/iot-gate-imx8plus-d1d8/contract.json
@@ -31,7 +31,7 @@
     "instructions": [
       "Unpack the balenaOS image you downloaded from balena-cloud.",
       "Make sure the device is not powered and connect the PROG port to your PC using a micro USB cable.",
-      "From a Linux-based host, use the <a href=\"https://github.com/balena-os/iot-gate-imx8plus-flashtools\">IOT-GATE-iMX8PLUS flashing tools</a> to write balenaOS on your device.",
+      "From a Linux-based host, use the [IOT-GATE-iMX8PLUS flashing tools](https://github.com/balena-os/iot-gate-imx8plus-flashtools) to write balenaOS on your device.",
       "After flashing is completed, disconnect the micro USB cable from the PROG port, power off the device and then power it back on."
     ]
   }

--- a/contracts/hw.device-type/iot-gate-imx8plus/contract.json
+++ b/contracts/hw.device-type/iot-gate-imx8plus/contract.json
@@ -31,7 +31,7 @@
     "instructions": [
       "Unpack the balenaOS image you downloaded from balena-cloud.",
       "Make sure the device is not powered and connect the PROG port to your PC using a micro USB cable.",
-      "From a Linux-based host, use the <a href=\"https://github.com/balena-os/iot-gate-imx8plus-flashtools\">IOT-GATE-iMX8PLUS flashing tools</a> to write balenaOS on your device.",
+      "From a Linux-based host, use the [IOT-GATE-iMX8PLUS flashing tools](https://github.com/balena-os/iot-gate-imx8plus-flashtools) to write balenaOS on your device.",
       "After flashing is completed, disconnect the micro USB cable from the PROG port, power off the device and then power it back on."
     ]
   }

--- a/contracts/hw.device-type/iotdin-imx8p-d1d8/contract.json
+++ b/contracts/hw.device-type/iotdin-imx8p-d1d8/contract.json
@@ -31,7 +31,7 @@
     "instructions": [
       "Unpack the balenaOS image you downloaded from balena-cloud.",
       "Make sure the device is not powered and connect the PROG port to your PC using a micro USB cable.",
-      "From a Linux-based host, use the <a href=\"https://github.com/balena-os/iot-gate-imx8plus-flashtools\">IOT-GATE-iMX8PLUS flashing tools</a> to write balenaOS on your device.",
+      "From a Linux-based host, use the [IOT-GATE-iMX8PLUS flashing tools](https://github.com/balena-os/iot-gate-imx8plus-flashtools) to write balenaOS on your device.",
       "After flashing is completed, disconnect the micro USB cable from the PROG port, power off the device and then power it back on."
     ]
   }

--- a/contracts/hw.device-type/iotdin-imx8p/contract.json
+++ b/contracts/hw.device-type/iotdin-imx8p/contract.json
@@ -31,7 +31,7 @@
     "instructions": [
       "Unpack the balenaOS image you downloaded from balena-cloud.",
       "Make sure the device is not powered and connect the PROG port to your PC using a micro USB cable.",
-      "From a Linux-based host, use the <a href=\"https://github.com/balena-os/iot-gate-imx8plus-flashtools\">IOT-GATE-iMX8PLUS flashing tools</a> to write balenaOS on your device.",
+      "From a Linux-based host, use the [IOT-GATE-iMX8PLUS flashing tools](https://github.com/balena-os/iot-gate-imx8plus-flashtools) to write balenaOS on your device.",
       "After flashing is completed, disconnect the micro USB cable from the PROG port, power off the device and then power it back on."
     ]
   }

--- a/contracts/hw.device-type/jetson-agx-orin-devkit-64gb/contract.json
+++ b/contracts/hw.device-type/jetson-agx-orin-devkit-64gb/contract.json
@@ -29,8 +29,8 @@
   },
   "partials": {
     "instructions": [
-        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the <a href=\"https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin\">firmware version</a> before proceeding.",
-        "For balenaOS versions older than v6.1.16, please refer to the <a href=\"https://github.com/balena-os/jetson-flash?tab=readme-ov-file\">{{name}} legacy flashing</a> guide."
+        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the [firmware version](https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin) before proceeding.",
+        "For balenaOS versions older than v6.1.16, please refer to the [{{name}} legacy flashing](https://github.com/balena-os/jetson-flash?tab=readme-ov-file) guide."
     ],
     "bootDeviceExternal": [
         "Power on the {{name}}.",

--- a/contracts/hw.device-type/jetson-orin-nano-devkit-nvme/contract.json
+++ b/contracts/hw.device-type/jetson-orin-nano-devkit-nvme/contract.json
@@ -29,8 +29,8 @@
   },
   "partials": {
     "instructions": [
-        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the <a href=\"https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin\">firmware version</a> before proceeding.",
-        "For balenaOS versions older than v6.1.16, please refer to the <a href=\"https://github.com/balena-os/jetson-flash?tab=readme-ov-file\">{{name}} legacy flashing</a> guide."
+        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the [firmware version](https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin) before proceeding.",
+        "For balenaOS versions older than v6.1.16, please refer to the [{{name}} legacy flashing](https://github.com/balena-os/jetson-flash?tab=readme-ov-file) guide."
     ],
     "bootDeviceExternal": [
         "Insert a NVME drive in the Devkit and power up the {{name}}."

--- a/contracts/hw.device-type/jetson-orin-nano-seeed-j3010/contract.json
+++ b/contracts/hw.device-type/jetson-orin-nano-seeed-j3010/contract.json
@@ -29,8 +29,8 @@
   },
   "partials": {
     "instructions": [
-        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the <a href=\"https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin\">firmware version</a> before proceeding.",
-        "For balenaOS versions older than v6.1.16, please refer to the <a href=\"https://github.com/balena-os/jetson-flash?tab=readme-ov-file\">{{name}} legacy flashing</a> guide."
+        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the [firmware version](https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin) before proceeding.",
+        "For balenaOS versions older than v6.1.16, please refer to the [{{name}} legacy flashing](https://github.com/balena-os/jetson-flash?tab=readme-ov-file) guide."
     ],
     "bootDeviceExternal": [
         "Insert a NVME drive in the Devkit and power up the {{name}}"

--- a/contracts/hw.device-type/jetson-orin-nx-seeed-j4012/contract.json
+++ b/contracts/hw.device-type/jetson-orin-nx-seeed-j4012/contract.json
@@ -29,8 +29,8 @@
   },
   "partials": {
     "instructions": [
-        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the <a href=\"https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin\">firmware version</a> before proceeding.",
-        "For balenaOS versions older than v6.1.16, please refer to the <a href=\"https://github.com/balena-os/jetson-flash?tab=readme-ov-file\">{{name}} legacy flashing</a> guide."
+        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the [firmware version](https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin) before proceeding.",
+        "For balenaOS versions older than v6.1.16, please refer to the [{{name}} legacy flashing](https://github.com/balena-os/jetson-flash?tab=readme-ov-file) guide."
     ],
     "bootDeviceExternal": [
         "Insert a NVME drive in the Devkit and power up the {{name}}."

--- a/contracts/hw.device-type/jetson-orin-nx-xavier-nx-devkit/contract.json
+++ b/contracts/hw.device-type/jetson-orin-nx-xavier-nx-devkit/contract.json
@@ -29,8 +29,8 @@
   },
   "partials": {
       "instructions": [
-        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the <a href=\"https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin\">firmware version</a> before proceeding.",
-        "For balenaOS versions older than v6.1.16, please refer to the <a href=\"https://github.com/balena-os/jetson-flash?tab=readme-ov-file\">{{name}} legacy flashing</a> guide."
+        "For balenaOS versions v6.1.16 and newer, please ensure your device is running UEFI firmware version 36.3. Check and update the [firmware version](https://docs.balena.io/learn/develop/hardware/jetson-orin#provisioning-jetson-orin) before proceeding.",
+        "For balenaOS versions older than v6.1.16, please refer to the [{{name}} legacy flashing](https://github.com/balena-os/jetson-flash?tab=readme-ov-file) guide."
     ],
     "bootDeviceExternal": [
         "Insert a NVME drive in the Devkit and power up the {{name}}."

--- a/contracts/hw.device-type/radxa-cm3-rpicm4-ioboard/contract.json
+++ b/contracts/hw.device-type/radxa-cm3-rpicm4-ioboard/contract.json
@@ -29,10 +29,10 @@
   },
   "partials": {
     "instructions": [
-     "Use the <a href=\"https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Boot_the_board_to_maskrom_mode\">maskrom mode</a> instructions supplied by the vendor and ensure the device's MicroUSB port is used for provisioning.",
-     "Install on your PC the <a href=\"https://wiki.radxa.com/Rock3/install/rockchip-flash-tools\">rockchip flash tools</a> required for flashing.",
-     "Clear eMMC and set it in UMS mode. Make sure to use <a href=\"https://dl.radxa.com/rock3/images/loader/rk356x_spl_loader_ddr1056_v1.06.110.bin\">this loader</a> when following the <a href=\"https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Begin_Installation_USB_-.3E_eMMC\">USB provisioning instructions</a>.",
-     "Once the OS has been written to the eMMC you need to repower your board. Make sure you take into account the <a href=\"https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Power_on\">power on instructions</a>."
+     "Use the [maskrom mode](https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Boot_the_board_to_maskrom_mode) instructions supplied by the vendor and ensure the device's MicroUSB port is used for provisioning.",
+     "Install on your PC the [rockchip flash tools](https://wiki.radxa.com/Rock3/install/rockchip-flash-tools) required for flashing.",
+     "Clear eMMC and set it in UMS mode. Make sure to use [this loader](https://dl.radxa.com/rock3/images/loader/rk356x_spl_loader_ddr1056_v1.06.110.bin) when following the [USB provisioning instructions](https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Begin_Installation_USB_-.3E_eMMC).",
+     "Once the OS has been written to the eMMC you need to repower your board. Make sure you take into account the [power on instructions](https://wiki.radxa.com/Rock3/installusb-install-radxa-cm3-rpi-cm4-io#Power_on)."
     ]
   }
 }

--- a/contracts/hw.device-type/radxa-zero/contract.json
+++ b/contracts/hw.device-type/radxa-zero/contract.json
@@ -29,10 +29,10 @@
   },
   "partials": {
     "instructions": [
-        "Use the <a href=\"https://wiki.radxa.com/Zero/dev/maskrom#Enable_maskrom\">maskrom mode</a> instructions provided by the vendor and make sure the board's USB2 port is used for provisioning.",
-        "Install on your PC the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Install_required_tools>tools</a> required for flashing.",
-        "Clear eMMC and set it in UMS mode. Make sure to use <a href=https://dl.radxa.com/zero/images/loader/radxa-zero-erase-emmc.bin>this loader</a> when following the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Side_loading_binaries>sideloading instructions</a>.",
-        "Write the OS to the internal eMMC storage device. We recommend using <a href=\"http://www.etcher.io\">Etcher</a>.",
+        "Use the [maskrom mode](https://wiki.radxa.com/Zero/dev/maskrom#Enable_maskrom) instructions provided by the vendor and make sure the board's USB2 port is used for provisioning.",
+        "Install on your PC the [tools](https://wiki.radxa.com/Zero/dev/maskrom#Install_required_tools) required for flashing.",
+        "Clear eMMC and set it in UMS mode. Make sure to use [this loader](https://dl.radxa.com/zero/images/loader/radxa-zero-erase-emmc.bin) when following the [sideloading instructions](https://wiki.radxa.com/Zero/dev/maskrom#Side_loading_binaries).",
+        "Write the OS to the internal eMMC storage device. We recommend using [Etcher](http://www.etcher.io).",
         "Once the OS has been written to the eMMC you need to repower your board."
     ]
   }

--- a/contracts/hw.device-type/raspberrypicm4-ioboard/contract.json
+++ b/contracts/hw.device-type/raspberrypicm4-ioboard/contract.json
@@ -31,7 +31,7 @@
   "partials": {
     "connectDevice": [
       "Fit the jumper to disable eMMC boot on J2 and connect the {{name}}'s microUSB port to your PC.",
-      "Power the board and use <a href='https://github.com/raspberrypi/usbboot'>usbboot</a> to put the eMMC in mass storage mode."
+      "Power the board and use [usbboot](https://github.com/raspberrypi/usbboot) to put the eMMC in mass storage mode."
     ],
     "disconnectDevice": ["Disconnect the power source and eMMC boot jumper."],
     "bootDevice": ["Remove and re-connect power to the {{name}}."]


### PR DESCRIPTION
... as per the internal thread
https://balena.zulipchat.com/#narrow/channel/350505-aspect.2Fgrowth/topic/Improving.20Jetson-flash.20documentation/near/493450821

Due to recent changes in the renderer, HTML links are no longer displayed.

Change-type: patch