### PR TITLE
Mark alpine 3.21 as the default alpine version

### DIFF
--- a/contracts/sw.os/alpine/contract.json
+++ b/contracts/sw.os/alpine/contract.json
@@ -4,7 +4,7 @@
   "version": "1",
   "data": {
     "libc": "musl-libc",
-    "latest": "3.20",
+    "latest": "3.21",
     "versionList": "`3.21 (latest)`, `3.20`, `3.19`, `3.18`, `3.17`, `3.16`, `3.15`, `3.14`, `3.13`, `3.12`, `edge`"
   },
   "name": "Alpine Linux {{this.version}}",


### PR DESCRIPTION
Change-type: patch
https://balena.zendesk.com/agent/tickets/4549