### PR TITLE
Remove EOL Ubuntu distros

### DIFF
--- a/contracts/sw.os/ubuntu/contract.json
+++ b/contracts/sw.os/ubuntu/contract.json
@@ -5,7 +5,7 @@
   "data": {
     "libc": "glibc",
     "latest": "noble",
-    "versionList": "`noble (latest)`, `jammy`, `xenial`"
+    "versionList": "`noble (latest)`, `jammy`"
   },
   "name": "Ubuntu {{this.version}}",
   "requires": [
@@ -35,16 +35,7 @@
       ],
       "variants": [
         { "version": "noble" },
-        { "version": "jammy" },
-        { "version": "xenial" }
-      ]
-    },
-    {
-      "requires": [
-        { "type": "arch.sw", "slug": "i386" }
-      ],
-      "variants": [
-        { "version": "xenial" }
+        { "version": "jammy" }
       ]
     },
     {
@@ -53,8 +44,7 @@
       ],
       "variants": [
         { "version": "noble" },
-        { "version": "jammy" },
-        { "version": "xenial" }
+        { "version": "jammy" }
       ]
     }
   ]

--- a/contracts/sw.os/ubuntu/contract.json
+++ b/contracts/sw.os/ubuntu/contract.json
@@ -5,7 +5,7 @@
   "data": {
     "libc": "glibc",
     "latest": "noble",
-    "versionList": "`noble (latest)`, `jammy`, `focal`, `xenial`, `bionic`"
+    "versionList": "`noble (latest)`, `jammy`, `xenial`, `bionic`"
   },
   "name": "Ubuntu {{this.version}}",
   "requires": [
@@ -36,7 +36,6 @@
       "variants": [
         { "version": "noble" },
         { "version": "jammy" },
-        { "version": "focal" },
         { "version": "xenial" },
         { "version": "bionic" }
       ]
@@ -57,7 +56,6 @@
       "variants": [
         { "version": "noble" },
         { "version": "jammy" },
-        { "version": "focal" },
         { "version": "xenial" },
         { "version": "bionic" }
       ]

--- a/contracts/sw.os/ubuntu/contract.json
+++ b/contracts/sw.os/ubuntu/contract.json
@@ -5,7 +5,7 @@
   "data": {
     "libc": "glibc",
     "latest": "noble",
-    "versionList": "`noble (latest)`, `jammy`, `xenial`, `bionic`"
+    "versionList": "`noble (latest)`, `jammy`, `xenial`"
   },
   "name": "Ubuntu {{this.version}}",
   "requires": [
@@ -36,8 +36,7 @@
       "variants": [
         { "version": "noble" },
         { "version": "jammy" },
-        { "version": "xenial" },
-        { "version": "bionic" }
+        { "version": "xenial" }
       ]
     },
     {
@@ -45,8 +44,7 @@
         { "type": "arch.sw", "slug": "i386" }
       ],
       "variants": [
-        { "version": "xenial" },
-        { "version": "bionic" }
+        { "version": "xenial" }
       ]
     },
     {
@@ -56,8 +54,7 @@
       "variants": [
         { "version": "noble" },
         { "version": "jammy" },
-        { "version": "xenial" },
-        { "version": "bionic" }
+        { "version": "xenial" }
       ]
     }
   ]

--- a/contracts/sw.stack+sw.os+hw.device-type/dotnet@3.1-aspnet+ubuntu@bionic/build.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/dotnet@3.1-aspnet+ubuntu@bionic/build.tpl
@@ -1,3 +1,0 @@
-{{import partial="ubuntu@bionic-dotnet-deps" combination="sw.stack+sw.os+hw.device-type"}}
-
-{{import partial="dotnet-aspnet-3.x" combination="sw.stack+sw.os+hw.device-type"}}

--- a/contracts/sw.stack+sw.os+hw.device-type/dotnet@3.1-aspnet+ubuntu@bionic/run.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/dotnet@3.1-aspnet+ubuntu@bionic/run.tpl
@@ -1,3 +1,0 @@
-{{import partial="ubuntu@bionic-dotnet-deps" combination="sw.stack+sw.os+hw.device-type"}}
-
-{{import partial="dotnet-aspnet-3.x" combination="sw.stack+sw.os+hw.device-type"}}

--- a/contracts/sw.stack+sw.os+hw.device-type/dotnet@3.1-runtime+ubuntu@bionic/build.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/dotnet@3.1-runtime+ubuntu@bionic/build.tpl
@@ -1,3 +1,0 @@
-{{import partial="ubuntu@bionic-dotnet-deps" combination="sw.stack+sw.os+hw.device-type"}}
-
-{{import partial="dotnet-runtime" combination="sw.stack+sw.os+hw.device-type"}}

--- a/contracts/sw.stack+sw.os+hw.device-type/dotnet@3.1-runtime+ubuntu@bionic/run.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/dotnet@3.1-runtime+ubuntu@bionic/run.tpl
@@ -1,3 +1,0 @@
-{{import partial="ubuntu@bionic-dotnet-deps" combination="sw.stack+sw.os+hw.device-type"}}
-
-{{import partial="dotnet-runtime" combination="sw.stack+sw.os+hw.device-type"}}

--- a/contracts/sw.stack+sw.os+hw.device-type/dotnet@3.1-sdk+ubuntu@bionic/build.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/dotnet@3.1-sdk+ubuntu@bionic/build.tpl
@@ -1,3 +1,0 @@
-{{import partial="ubuntu@bionic-dotnet-deps" combination="sw.stack+sw.os+hw.device-type"}}
-
-{{import partial="dotnet-sdk" combination="sw.stack+sw.os+hw.device-type"}}

--- a/contracts/sw.stack+sw.os+hw.device-type/dotnet@3.1-sdk+ubuntu@bionic/run.tpl
+++ b/contracts/sw.stack+sw.os+hw.device-type/dotnet@3.1-sdk+ubuntu@bionic/run.tpl
@@ -1,3 +1,0 @@
-{{import partial="ubuntu@bionic-dotnet-deps" combination="sw.stack+sw.os+hw.device-type"}}
-
-{{import partial="dotnet-sdk" combination="sw.stack+sw.os+hw.device-type"}}

--- a/contracts/sw.stack/dotnet/contract.json
+++ b/contracts/sw.stack/dotnet/contract.json
@@ -61,7 +61,6 @@
           "requires": [
             {
               "or": [
-                { "type": "sw.os", "slug": "ubuntu", "version": "focal" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "noble" },
@@ -123,7 +122,6 @@
           "requires": [
             {
               "or": [
-                { "type": "sw.os", "slug": "ubuntu", "version": "focal" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "noble" },
@@ -185,7 +183,6 @@
           "requires": [
             {
               "or": [
-                { "type": "sw.os", "slug": "ubuntu", "version": "focal" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "noble" },
@@ -247,7 +244,6 @@
           "requires": [
             {
               "or": [
-                { "type": "sw.os", "slug": "ubuntu", "version": "focal" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "noble" },
@@ -317,7 +313,6 @@
           "requires": [
             {
               "or": [
-                { "type": "sw.os", "slug": "ubuntu", "version": "focal" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "noble" },
@@ -395,7 +390,6 @@
           "requires": [
             {
               "or": [
-                { "type": "sw.os", "slug": "ubuntu", "version": "focal" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "noble" },

--- a/contracts/sw.stack/openjdk/contract.json
+++ b/contracts/sw.stack/openjdk/contract.json
@@ -34,7 +34,6 @@
             { "type": "sw.os", "slug": "debian", "version": "bullseye" },
             { "type": "sw.os", "slug": "debian", "version": "bookworm" },
             { "type": "sw.os", "slug": "ubuntu", "version": "xenial" },
-            { "type": "sw.os", "slug": "ubuntu", "version": "bionic" },
             { "type": "sw.os", "slug": "fedora", "version": "30" },
             { "type": "sw.os", "slug": "fedora", "version": "29" },
             { "type": "sw.os", "slug": "fedora", "version": "28" }
@@ -51,7 +50,6 @@
             { "type": "sw.os", "slug": "debian", "version": "bullseye" },
             { "type": "sw.os", "slug": "debian", "version": "bookworm" },
             { "type": "sw.os", "slug": "ubuntu", "version": "xenial" },
-            { "type": "sw.os", "slug": "ubuntu", "version": "bionic" },
             { "type": "sw.os", "slug": "fedora", "version": "30" },
             { "type": "sw.os", "slug": "fedora", "version": "29" },
             { "type": "sw.os", "slug": "fedora", "version": "28" }

--- a/contracts/sw.stack/openjdk/contract.json
+++ b/contracts/sw.stack/openjdk/contract.json
@@ -33,7 +33,6 @@
             { "type": "sw.os", "slug": "debian", "version": "buster" },
             { "type": "sw.os", "slug": "debian", "version": "bullseye" },
             { "type": "sw.os", "slug": "debian", "version": "bookworm" },
-            { "type": "sw.os", "slug": "ubuntu", "version": "xenial" },
             { "type": "sw.os", "slug": "fedora", "version": "30" },
             { "type": "sw.os", "slug": "fedora", "version": "29" },
             { "type": "sw.os", "slug": "fedora", "version": "28" }
@@ -49,7 +48,6 @@
             { "type": "sw.os", "slug": "debian", "version": "buster" },
             { "type": "sw.os", "slug": "debian", "version": "bullseye" },
             { "type": "sw.os", "slug": "debian", "version": "bookworm" },
-            { "type": "sw.os", "slug": "ubuntu", "version": "xenial" },
             { "type": "sw.os", "slug": "fedora", "version": "30" },
             { "type": "sw.os", "slug": "fedora", "version": "29" },
             { "type": "sw.os", "slug": "fedora", "version": "28" }

--- a/contracts/sw.stack/python/contract.json
+++ b/contracts/sw.stack/python/contract.json
@@ -447,8 +447,7 @@
               "requires": [
                 {
                   "or": [
-                    { "type": "sw.os", "slug": "debian" , "version": "buster" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "xenial" }
+                    { "type": "sw.os", "slug": "debian" , "version": "buster" }
                   ]
                 }
               ],
@@ -913,8 +912,7 @@
               "requires": [
                 {
                   "or": [
-                    { "type": "sw.os", "slug": "debian" , "version": "buster" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "xenial" }
+                    { "type": "sw.os", "slug": "debian" , "version": "buster" }
                   ]
                 }
               ],
@@ -1379,8 +1377,7 @@
               "requires": [
                 {
                   "or": [
-                    { "type": "sw.os", "slug": "debian" , "version": "buster" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "xenial" }
+                    { "type": "sw.os", "slug": "debian" , "version": "buster" }
                   ]
                 }
               ],
@@ -1845,8 +1842,7 @@
               "requires": [
                 {
                   "or": [
-                    { "type": "sw.os", "slug": "debian" , "version": "buster" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "xenial" }
+                    { "type": "sw.os", "slug": "debian" , "version": "buster" }
                   ]
                 }
               ],
@@ -2299,8 +2295,7 @@
               "requires": [
                 {
                   "or": [
-                    { "type": "sw.os", "slug": "debian" , "version": "buster" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "xenial" }
+                    { "type": "sw.os", "slug": "debian" , "version": "buster" }
                   ]
                 }
               ],

--- a/contracts/sw.stack/python/contract.json
+++ b/contracts/sw.stack/python/contract.json
@@ -376,7 +376,6 @@
                 {
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "bullseye" },
-                    { "type": "sw.os", "slug": "ubuntu", "version": "focal" },
                     { "type": "sw.os", "slug": "fedora" }
                   ]
                 }
@@ -856,7 +855,6 @@
                 {
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "bullseye" },
-                    { "type": "sw.os", "slug": "ubuntu", "version": "focal" },
                     { "type": "sw.os", "slug": "fedora" }
                   ]
                 }
@@ -1324,7 +1322,6 @@
                 {
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "bullseye" },
-                    { "type": "sw.os", "slug": "ubuntu", "version": "focal" },
                     { "type": "sw.os", "slug": "fedora" }
                   ]
                 }
@@ -1792,7 +1789,6 @@
                 {
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "bullseye" },
-                    { "type": "sw.os", "slug": "ubuntu", "version": "focal" },
                     { "type": "sw.os", "slug": "fedora" }
                   ]
                 }
@@ -2260,7 +2256,6 @@
                 {
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "bullseye" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "focal" },
                     { "type": "sw.os", "slug": "fedora" }
                   ]
                 }

--- a/contracts/sw.stack/python/contract.json
+++ b/contracts/sw.stack/python/contract.json
@@ -448,7 +448,6 @@
                 {
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "buster" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "xenial" }
                   ]
                 }
@@ -915,7 +914,6 @@
                 {
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "buster" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "xenial" }
                   ]
                 }
@@ -1382,7 +1380,6 @@
                 {
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "buster" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "xenial" }
                   ]
                 }
@@ -1849,7 +1846,6 @@
                 {
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "buster" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "xenial" }
                   ]
                 }
@@ -2304,7 +2300,6 @@
                 {
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "buster" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "bionic" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "xenial" }
                   ]
                 }


### PR DESCRIPTION
Focal is EOL in May 2025

Bionic was EOL in May 2023

Xenial was EOL in April 2021