### PR TITLE
Remove Ubuntu Lunar 23.04 leftovers from dotnet & python contracts

### DIFF
--- a/contracts/sw.stack/dotnet/contract.json
+++ b/contracts/sw.stack/dotnet/contract.json
@@ -61,7 +61,6 @@
           "requires": [
             {
               "or": [
-                { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "noble" },
                 { "type": "sw.os", "slug": "debian", "version": "bullseye" },
@@ -122,7 +121,6 @@
           "requires": [
             {
               "or": [
-                { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "noble" },
                 { "type": "sw.os", "slug": "debian", "version": "bullseye" },
@@ -183,7 +181,6 @@
           "requires": [
             {
               "or": [
-                { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "noble" },
                 { "type": "sw.os", "slug": "debian", "version": "bullseye" },
@@ -244,7 +241,6 @@
           "requires": [
             {
               "or": [
-                { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "noble" },
                 { "type": "sw.os", "slug": "debian", "version": "bullseye" },
@@ -313,7 +309,6 @@
           "requires": [
             {
               "or": [
-                { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "noble" },
                 { "type": "sw.os", "slug": "debian", "version": "bullseye" },
@@ -390,7 +385,6 @@
           "requires": [
             {
               "or": [
-                { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                 { "type": "sw.os", "slug": "ubuntu" , "version": "noble" },
                 { "type": "sw.os", "slug": "debian", "version": "bullseye" },

--- a/contracts/sw.stack/python/contract.json
+++ b/contracts/sw.stack/python/contract.json
@@ -302,7 +302,6 @@
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "sid" },
                     { "type": "sw.os", "slug": "debian", "version": "bookworm" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "noble" }
                   ]
@@ -779,7 +778,6 @@
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "sid" },
                     { "type": "sw.os", "slug": "debian", "version": "bookworm" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "noble" }
                   ]
@@ -1244,7 +1242,6 @@
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "sid" },
                     { "type": "sw.os", "slug": "debian", "version": "bookworm" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "noble" }
                   ]
@@ -1709,7 +1706,6 @@
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "sid" },
                     { "type": "sw.os", "slug": "debian", "version": "bookworm" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "noble" }
                   ]
@@ -2174,7 +2170,6 @@
                   "or": [
                     { "type": "sw.os", "slug": "debian" , "version": "sid" },
                     { "type": "sw.os", "slug": "debian", "version": "bookworm" },
-                    { "type": "sw.os", "slug": "ubuntu" , "version": "lunar" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "jammy" },
                     { "type": "sw.os", "slug": "ubuntu" , "version": "noble" }
                   ]


### PR DESCRIPTION
Change-type: patch