### PR TITLE
hw.device-type/beaglebone-ai64: Add the beaglebone-ai-64 alias to align with its device repo definition

### DIFF
--- a/contracts/hw.device-type/beaglebone-ai64/contract.json
+++ b/contracts/hw.device-type/beaglebone-ai64/contract.json
@@ -2,7 +2,7 @@
   "slug": "beaglebone-ai64",
   "version": "1",
   "type": "hw.device-type",
-  "aliases": [""],
+  "aliases": ["beaglebone-ai-64"],
   "name": "BeagleBone AI64",
   "assets": {
     "logo": {


### PR DESCRIPTION
Change-type: patch
See: https://github.com/balena-os/balena-beaglebone/blob/v6.12.11/beaglebone-ai64.coffee#L16
See: https://github.com/balena-io/open-balena-api/pull/2300
See: https://balena.fibery.io/Work/Project/2470