### PR TITLE
revpi-connect-4: remove led

### DIFF
--- a/contracts/hw.device-type/revpi-connect-4/contract.json
+++ b/contracts/hw.device-type/revpi-connect-4/contract.json
@@ -14,7 +14,7 @@
     "arch": "aarch64",
     "family": "kunbus-broadcom",
     "hdmi": true,
-    "led": true,
+    "led": false,
     "connectivity": {
       "bluetooth": true,
       "wifi": true


### PR DESCRIPTION
This device type has no LED.

Relates-to: https://balena.zulipchat.com/#narrow/channel/345889-balena-io.2Fos/topic/raspberrypi.20pipeline/near/619759972
Change-type: patch